### PR TITLE
Refactor strategies into modular files and add headless tournament runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,42 @@ Then visit <http://localhost:8000>.
 ## Strategies
 
 `SlowAndSteady`, `Repel`, `Trinity`, `Aggressive`, `Defender`, `Random`,
-`Berserker`, `Cautious`, `Swarm`. Drop new ones into `src/strategies/index.js`
-and they appear in the HUD automatically.
+`Berserker`, `Cautious`, `Swarm`. One file per bot in `src/strategies/`,
+registered in `src/strategies/index.js`. See [docs/strategies.md](docs/strategies.md)
+for the bot-author guide.
+
+## Tournaments
+
+Headless bot tournaments run on Node (>= 19):
+
+```bash
+node tournament/run.js                              # all bots, arena, 10 rounds
+node tournament/run.js --bots Aggressive,Trinity    # specific lineup
+node tournament/run.js --map royale --rounds 30     # different map / longer
+node tournament/run.js --list                       # what's available
+node tournament/run.js --help
+```
+
+Matches are reproducible: `node tournament/run.js --seed 42` always produces
+the same standings.
 
 ## Architecture
 
 ```
 src/
-  core/        Game, GameMap, Tile, Army, Player, GamePos
-  strategies/  AI behaviors (army -> game)
-  modes/       Preset configs and starting positions
+  core/        Game, GameMap, Tile, Army, Player, GamePos, rng
+  strategies/  One file per bot + a registry index
+  modes/       Preset configs and starting positions (browser)
   render/      HiDPI canvas renderer + stats chart
   ui/          HUD player cards, control bar
-  main.js      App entry
+  main.js      Browser app entry
+tournament/
+  arena.js     Headless single-match runner
+  scheduler.js Round-robin / FFA scheduler
+  maps.js      Map presets for tournaments
+  run.js       CLI entrypoint
+docs/
+  strategies.md  Bot-author guide
 ```
 
-Plain ES modules. No bundler. No framework.
+Plain ES modules. No bundler. No framework. No `npm install`.

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,134 @@
+# Writing a PixelWars bot
+
+A strategy is a tiny ES module that decides what one army does on each tick.
+
+## File layout
+
+Drop a new file in `src/strategies/` named after your bot, e.g.
+`src/strategies/Stormtrooper.js`. Default-export a strategy object:
+
+```js
+// src/strategies/Stormtrooper.js
+import { totalStrength } from "../core/Army.js";
+
+export default {
+  name: "Stormtrooper",   // unique, matches the filename
+  author: "shady",        // freeform
+  version: 1,
+  description: "Always misses, but with great enthusiasm.",
+  act(army, game) {
+    // your logic here
+  },
+};
+```
+
+Then add it to the registry list in `src/strategies/index.js`:
+
+```js
+import Stormtrooper from "./Stormtrooper.js";
+// ...
+export const STRATEGY_LIST = [..., Stormtrooper];
+```
+
+That's it. The bot now appears in the browser HUD dropdown, in the Node
+tournament runner, and in `--list`.
+
+## The `act(army, game)` contract
+
+`act` is called once per army per tick. You decide what *this* army does;
+you don't see or control your other armies directly. State you store on
+`army` persists for the army's lifetime; state on `game` persists for the
+match.
+
+### What you read from `army`
+
+| Field            | Meaning |
+|------------------|---------|
+| `army.pos`       | `{ x, y }` of the tile this army occupies |
+| `army.strength`  | Current strength (a float, capped by `maxStrength`) |
+| `army.maxStrength` | Cap from `Game.maxArmy` |
+| `army.player`    | Owning player; compare with `army.player.equals(other)` |
+
+### What you read from `game`
+
+| Call                         | Returns |
+|------------------------------|---------|
+| `game.map.getTile(x, y)`     | Tile or `null` (handles wrap) |
+| `game.map.adjacent(pos, d)`  | Tile in direction `d` (0=W, 1=E, 2=N, 3=S) |
+| `game.map.neighbors(pos)`    | 4-tile array, omitting nulls |
+| `tile.armies`                | Armies on a tile (read-only — don't mutate) |
+| `game.rng()`                 | Seeded float in `[0, 1)`. Use this, NOT `Math.random()` |
+| `game.tick`, `game.elapsed`  | Match clock |
+| `game.players.list`          | All players |
+
+### Helpers on `army`
+
+- `army.weakestAdjacent(gradient?)` — returns the neighboring tile with the
+  least net enemy strength. Optional gradient is `[w, e, n, s]` and biases
+  the score per direction.
+
+### What you do (the only "actions")
+
+```js
+army.attack(tile, power)
+```
+
+Sends `power` strength toward `tile`. The remaining strength stays put.
+Returns `false` and is a no-op when the move is invalid:
+
+- tile must be adjacent (not your own tile)
+- `power > 0.5`
+- you must keep at least 1 strength behind (`army.strength - power >= 1`)
+
+That's it. No teleport, no merging, no surrender. Conflict resolution
+(combine with friendlies, fight enemies) happens automatically at the end
+of the tick.
+
+## Determinism
+
+Tournaments are reproducible. The seed lives on `game.rng`. If your bot
+needs randomness, route it through `game.rng()` so two runs with the same
+seed produce the same outcome. Bots that call `Math.random()` will still
+work, but they cannot be replayed.
+
+## Helpers shared by core bots
+
+`src/strategies/helpers.js` exports `balanceAttack(army, tile)` —
+sends just enough force to either reinforce a friendly tile to parity or
+overpower an enemy with margin 1. Reuse it or roll your own.
+
+## Style guide
+
+- One bot per file. The filename and `name` field should match.
+- No globals, no module-level mutable state. State per army goes on
+  `army`; state per match goes on `game`.
+- Don't mutate other players' armies, tiles, or scores.
+- Don't import the renderer / DOM — bots must run headless.
+- Cheap is good. `act` runs O(armies × ticks) times per match.
+
+## Running a tournament
+
+```bash
+# All registered bots, arena map, 10 rounds
+npm run tournament
+
+# A specific lineup
+node tournament/run.js --bots Stormtrooper,Aggressive,Trinity --rounds 20
+
+# Different map and tick budget
+node tournament/run.js --map royale --rounds 30 --ticks 6000
+
+# JSON for plotting
+node tournament/run.js --json > results.json
+
+# See what's available
+node tournament/run.js --list
+```
+
+Scoring is Borda: in an `N`-bot match, 1st gets `N-1` points, last gets
+`0`. Ties broken by average rank. Survivors always outrank the dead;
+among the dead, dying later beats dying earlier; among survivors, more
+territory wins.
+
+Starting positions are rotated each round so every bot visits every
+slot — no positional bias.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pixelwars",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Tile-based strategy sandbox with bot tournaments",
+  "type": "module",
+  "engines": {
+    "node": ">=19"
+  },
+  "scripts": {
+    "tournament": "node tournament/run.js",
+    "serve": "python3 -m http.server 8000"
+  }
+}

--- a/src/core/Army.js
+++ b/src/core/Army.js
@@ -79,7 +79,10 @@ export class Army {
     const max = this.maxStrength;
     if (s > max) s = max;
     this.strength = s;
-    this.player.strategy(this, this.game);
+    const strat = this.player.strategy;
+    if (!strat) return;
+    if (typeof strat === "function") strat(this, this.game);
+    else if (typeof strat.act === "function") strat.act(this, this.game);
   }
 
   weakestAdjacent(gradient = null) {

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -1,9 +1,18 @@
 import { GameMap } from "./GameMap.js";
 import { Army } from "./Army.js";
 import { Players } from "./Player.js";
+import { makeRng } from "./rng.js";
 
 export class Game {
-  constructor({ width = 40, height = 30, wrap = true, growth = 1, maxArmy = 10, maxHistory = 240 } = {}) {
+  constructor({
+    width = 40,
+    height = 30,
+    wrap = true,
+    growth = 1,
+    maxArmy = 10,
+    maxHistory = 240,
+    seed = null,
+  } = {}) {
     this.map = new GameMap({ width, height, wrap });
     this.players = new Players();
     this.armies = [];
@@ -15,15 +24,18 @@ export class Game {
     this.maxArmy = maxArmy;
     this.history = [];
     this.maxHistory = maxHistory;
-    this.eventBus = new EventTarget();
+    this.seed = seed;
+    this.rng = makeRng(seed);
+    this.eventBus = typeof EventTarget !== "undefined" ? new EventTarget() : null;
     this._territoryDirty = true;
   }
 
   on(event, fn) {
-    this.eventBus.addEventListener(event, fn);
+    this.eventBus?.addEventListener(event, fn);
   }
 
   emit(event, detail) {
+    if (!this.eventBus || typeof CustomEvent === "undefined") return;
     this.eventBus.dispatchEvent(new CustomEvent(event, { detail }));
   }
 

--- a/src/core/rng.js
+++ b/src/core/rng.js
@@ -1,0 +1,17 @@
+// Mulberry32 — small fast deterministic PRNG.
+// Returns a function that yields floats in [0, 1).
+export function mulberry32(seed) {
+  let a = (seed >>> 0) || 1;
+  return function rng() {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export function makeRng(seed) {
+  if (seed === null || seed === undefined) return Math.random;
+  return mulberry32(seed);
+}

--- a/src/strategies/Aggressive.js
+++ b/src/strategies/Aggressive.js
@@ -1,0 +1,35 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+export default {
+  name: "Aggressive",
+  author: "core",
+  version: 1,
+  description: "Picks the strongest enemy it can still beat; otherwise plays SlowAndSteady.",
+  act(army, game) {
+    const neighbors = army.tile ? army.tile.neighbors : null;
+    const pid = army.player.id;
+    let best = null;
+    let bestScore = -Infinity;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
+      if (!t) continue;
+      const armies = t.armies;
+      let enemyTotal = 0;
+      let hasEnemy = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id !== pid) {
+          enemyTotal += a.strength;
+          hasEnemy = true;
+        }
+      }
+      if (!hasEnemy) continue;
+      if (enemyTotal > bestScore && enemyTotal < army.strength - 1) {
+        bestScore = enemyTotal;
+        best = t;
+      }
+    }
+    if (best) army.attack(best, army.strength - 1);
+    else SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Berserker.js
+++ b/src/strategies/Berserker.js
@@ -1,0 +1,13 @@
+export default {
+  name: "Berserker",
+  author: "core",
+  version: 1,
+  description: "Throws everything in a random direction every tick.",
+  act(army, game) {
+    if (army.strength < 2) return;
+    const dir = (game.rng() * 4) | 0;
+    const tile = army.tile ? army.tile.neighbors[dir] : game.map.adjacent(army.pos, dir);
+    if (!tile) return;
+    army.attack(tile, army.strength - 1);
+  },
+};

--- a/src/strategies/Cautious.js
+++ b/src/strategies/Cautious.js
@@ -1,0 +1,12 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+export default {
+  name: "Cautious",
+  author: "core",
+  version: 1,
+  description: "Sits on its hands until well above 70% strength, then plays SlowAndSteady.",
+  act(army, game) {
+    if (army.strength < army.maxStrength * 0.7) return;
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Defender.js
+++ b/src/strategies/Defender.js
@@ -1,0 +1,32 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+export default {
+  name: "Defender",
+  author: "core",
+  version: 1,
+  description: "Reinforces the friendliest neighbor; expands only when nearly full.",
+  act(army, game) {
+    const neighbors = army.tile ? army.tile.neighbors : null;
+    const pid = army.player.id;
+    let friendliest = null;
+    let count = 0;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
+      if (!t) continue;
+      const armies = t.armies;
+      let friendly = 0;
+      for (let k = 0; k < armies.length; k++) {
+        if (armies[k].player.id === pid) friendly++;
+      }
+      if (friendly > count) {
+        count = friendly;
+        friendliest = t;
+      }
+    }
+    if (count > 0 && army.strength > 4) {
+      army.attack(friendliest, army.strength * 0.5);
+      return;
+    }
+    if (army.strength > army.maxStrength * 0.85) SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Random.js
+++ b/src/strategies/Random.js
@@ -1,0 +1,12 @@
+export default {
+  name: "Random",
+  author: "core",
+  version: 1,
+  description: "Random direction, random force. Pure chaos.",
+  act(army, game) {
+    const dir = (game.rng() * 4) | 0;
+    const tile = army.tile ? army.tile.neighbors[dir] : game.map.adjacent(army.pos, dir);
+    if (!tile) return;
+    army.attack(tile, game.rng() * (army.strength - 1));
+  },
+};

--- a/src/strategies/Repel.js
+++ b/src/strategies/Repel.js
@@ -1,0 +1,15 @@
+import { balanceAttack } from "./helpers.js";
+
+const GRADIENT = [-2, 2, -2, 3];
+
+export default {
+  name: "Repel",
+  author: "core",
+  version: 1,
+  description: "Like SlowAndSteady, but biases movement away from the home corner.",
+  act(army) {
+    const tile = army.weakestAdjacent(GRADIENT);
+    if (!tile) return;
+    balanceAttack(army, tile);
+  },
+};

--- a/src/strategies/SlowAndSteady.js
+++ b/src/strategies/SlowAndSteady.js
@@ -1,0 +1,13 @@
+import { balanceAttack } from "./helpers.js";
+
+export default {
+  name: "SlowAndSteady",
+  author: "core",
+  version: 1,
+  description: "Always splits toward the weakest neighbor with a balanced attack.",
+  act(army) {
+    const tile = army.weakestAdjacent();
+    if (!tile) return;
+    balanceAttack(army, tile);
+  },
+};

--- a/src/strategies/Swarm.js
+++ b/src/strategies/Swarm.js
@@ -1,0 +1,30 @@
+export default {
+  name: "Swarm",
+  author: "core",
+  version: 1,
+  description: "Sends small probes toward weak enemies, preferring lonely tiles.",
+  act(army, game) {
+    const neighbors = army.tile ? army.tile.neighbors : null;
+    const pid = army.player.id;
+    let best = null;
+    let bestScore = Infinity;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
+      if (!t) continue;
+      const armies = t.armies;
+      let friendly = 0;
+      let enemyS = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendly++;
+        else enemyS += a.strength;
+      }
+      const score = enemyS - friendly * 0.5;
+      if (score < bestScore && enemyS < army.strength - 0.5) {
+        bestScore = score;
+        best = t;
+      }
+    }
+    if (best) army.attack(best, Math.min(army.strength - 1, army.strength * 0.4 + 0.5));
+  },
+};

--- a/src/strategies/Trinity.js
+++ b/src/strategies/Trinity.js
@@ -1,0 +1,75 @@
+import { sumStrength } from "../core/Army.js";
+
+const KERNELS = [
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+];
+
+// Precompute (stencilIdx, weight) tuples per kernel, dropping zero entries.
+// stencilIdx matches Tile.stencil5 layout: row-major over [-2..2] x [-2..2].
+const OFFSETS = KERNELS.map((k) => {
+  const out = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const w = k[i][j];
+      if (w !== 0) out.push(i * 5 + j, w);
+    }
+  }
+  return out;
+});
+
+export default {
+  name: "Trinity",
+  author: "core",
+  version: 1,
+  description: "Convolves friendly density with three-in-a-row kernels and pushes that way.",
+  act(army) {
+    const tile = army.tile;
+    if (!tile) return;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+    let bestDir = 0;
+    let bestScore = -Infinity;
+    for (let k = 0; k < 4; k++) {
+      const offs = OFFSETS[k];
+      let score = 0;
+      for (let n = 0; n < offs.length; n += 2) {
+        const t = stencil[offs[n]];
+        if (!t) continue;
+        score += offs[n + 1] * sumStrength(t.armies, viewer);
+      }
+      if (score > bestScore) {
+        bestScore = score;
+        bestDir = k;
+      }
+    }
+    const target = tile.neighbors[bestDir];
+    if (target) army.attack(target, army.strength - 1);
+  },
+};

--- a/src/strategies/helpers.js
+++ b/src/strategies/helpers.js
@@ -1,0 +1,14 @@
+import { totalStrength } from "../core/Army.js";
+
+export function balanceAttack(army, tile) {
+  const armies = tile.armies;
+  if (armies.length > 0 && armies[0].player.id === army.player.id) {
+    const enemyStrength = totalStrength(armies);
+    army.attack(tile, army.strength - (army.strength + enemyStrength) / 2);
+    return;
+  }
+  const enemy = totalStrength(armies);
+  if (enemy + 1 < army.strength) {
+    army.attack(tile, army.strength - 1);
+  }
+}

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -1,198 +1,14 @@
-import { sumStrength, totalStrength } from "../core/Army.js";
+import SlowAndSteady from "./SlowAndSteady.js";
+import Repel from "./Repel.js";
+import Trinity from "./Trinity.js";
+import Aggressive from "./Aggressive.js";
+import Defender from "./Defender.js";
+import Random from "./Random.js";
+import Berserker from "./Berserker.js";
+import Cautious from "./Cautious.js";
+import Swarm from "./Swarm.js";
 
-function balanceAttack(army, tile) {
-  const armies = tile.armies;
-  if (armies.length > 0 && armies[0].player.id === army.player.id) {
-    const enemyStrength = totalStrength(armies);
-    army.attack(tile, army.strength - (army.strength + enemyStrength) / 2);
-    return;
-  }
-  const enemy = totalStrength(armies);
-  if (enemy + 1 < army.strength) {
-    army.attack(tile, army.strength - 1);
-  }
-}
-
-export function SlowAndSteady(army) {
-  const tile = army.weakestAdjacent();
-  if (!tile) return;
-  balanceAttack(army, tile);
-}
-
-const REPEL_GRADIENT = [-2, 2, -2, 3];
-export function Repel(army) {
-  const tile = army.weakestAdjacent(REPEL_GRADIENT);
-  if (!tile) return;
-  balanceAttack(army, tile);
-}
-
-const TRINITY_KERNELS = [
-  [
-    [0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 0],
-    [0, 0, 0, 1, 0],
-    [0, 0, 1, 0, 0],
-    [0, 0, 0, 0, 0],
-  ],
-  [
-    [0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 0],
-    [0, 1, 0, 0, 0],
-    [0, 0, 1, 0, 0],
-    [0, 0, 0, 0, 0],
-  ],
-  [
-    [0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0],
-    [0, 1, 0, 1, 0],
-    [0, 0, 1, 0, 0],
-    [0, 0, 0, 0, 0],
-  ],
-  [
-    [0, 0, 0, 0, 0],
-    [0, 0, 1, 0, 0],
-    [0, 1, 0, 1, 0],
-    [0, 0, 0, 0, 0],
-    [0, 0, 0, 0, 0],
-  ],
-];
-
-// Precompute (stencilIdx, weight) tuples for each kernel, dropping zero entries.
-// stencilIdx matches Tile.stencil5 layout: row-major over [-2..2] x [-2..2].
-const TRINITY_OFFSETS = TRINITY_KERNELS.map((k) => {
-  const out = [];
-  for (let i = 0; i < 5; i++) {
-    for (let j = 0; j < 5; j++) {
-      const w = k[i][j];
-      if (w !== 0) out.push(i * 5 + j, w);
-    }
-  }
-  return out;
-});
-
-export function Trinity(army, game) {
-  const tile = army.tile;
-  if (!tile) return;
-  const stencil = tile.stencil5;
-  const viewer = army.player;
-  let bestDir = 0;
-  let bestScore = -Infinity;
-  for (let k = 0; k < 4; k++) {
-    const offs = TRINITY_OFFSETS[k];
-    let score = 0;
-    for (let n = 0; n < offs.length; n += 2) {
-      const t = stencil[offs[n]];
-      if (!t) continue;
-      score += offs[n + 1] * sumStrength(t.armies, viewer);
-    }
-    if (score > bestScore) {
-      bestScore = score;
-      bestDir = k;
-    }
-  }
-  const target = tile.neighbors[bestDir];
-  if (target) army.attack(target, army.strength - 1);
-}
-
-export function Aggressive(army, game) {
-  const neighbors = army.tile ? army.tile.neighbors : null;
-  const pid = army.player.id;
-  let best = null;
-  let bestScore = -Infinity;
-  for (let i = 0; i < 4; i++) {
-    const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
-    if (!t) continue;
-    const armies = t.armies;
-    let enemyTotal = 0;
-    let hasEnemy = false;
-    for (let k = 0; k < armies.length; k++) {
-      const a = armies[k];
-      if (a.player.id !== pid) {
-        enemyTotal += a.strength;
-        hasEnemy = true;
-      }
-    }
-    if (!hasEnemy) continue;
-    if (enemyTotal > bestScore && enemyTotal < army.strength - 1) {
-      bestScore = enemyTotal;
-      best = t;
-    }
-  }
-  if (best) army.attack(best, army.strength - 1);
-  else SlowAndSteady(army, game);
-}
-
-export function Defender(army, game) {
-  const neighbors = army.tile ? army.tile.neighbors : null;
-  const pid = army.player.id;
-  let friendliest = null;
-  let count = 0;
-  for (let i = 0; i < 4; i++) {
-    const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
-    if (!t) continue;
-    const armies = t.armies;
-    let friendly = 0;
-    for (let k = 0; k < armies.length; k++) {
-      if (armies[k].player.id === pid) friendly++;
-    }
-    if (friendly > count) {
-      count = friendly;
-      friendliest = t;
-    }
-  }
-  if (count > 0 && army.strength > 4) {
-    army.attack(friendliest, army.strength * 0.5);
-    return;
-  }
-  if (army.strength > army.maxStrength * 0.85) SlowAndSteady(army, game);
-}
-
-export function Random(army, game) {
-  const dir = (Math.random() * 4) | 0;
-  const tile = army.tile ? army.tile.neighbors[dir] : game.map.adjacent(army.pos, dir);
-  if (!tile) return;
-  army.attack(tile, Math.random() * (army.strength - 1));
-}
-
-export function Berserker(army, game) {
-  if (army.strength < 2) return;
-  const dir = (Math.random() * 4) | 0;
-  const tile = army.tile ? army.tile.neighbors[dir] : game.map.adjacent(army.pos, dir);
-  if (!tile) return;
-  army.attack(tile, army.strength - 1);
-}
-
-export function Cautious(army, game) {
-  if (army.strength < army.maxStrength * 0.7) return;
-  SlowAndSteady(army, game);
-}
-
-export function Swarm(army, game) {
-  const neighbors = army.tile ? army.tile.neighbors : null;
-  const pid = army.player.id;
-  let best = null;
-  let bestScore = Infinity;
-  for (let i = 0; i < 4; i++) {
-    const t = neighbors ? neighbors[i] : game.map.adjacent(army.pos, i);
-    if (!t) continue;
-    const armies = t.armies;
-    let friendly = 0;
-    let enemyS = 0;
-    for (let k = 0; k < armies.length; k++) {
-      const a = armies[k];
-      if (a.player.id === pid) friendly++;
-      else enemyS += a.strength;
-    }
-    const score = enemyS - friendly * 0.5;
-    if (score < bestScore && enemyS < army.strength - 0.5) {
-      bestScore = score;
-      best = t;
-    }
-  }
-  if (best) army.attack(best, Math.min(army.strength - 1, army.strength * 0.4 + 0.5));
-}
-
-export const STRATEGIES = {
+export const STRATEGY_LIST = [
   SlowAndSteady,
   Repel,
   Trinity,
@@ -202,4 +18,12 @@ export const STRATEGIES = {
   Berserker,
   Cautious,
   Swarm,
-};
+];
+
+export const STRATEGIES = Object.fromEntries(STRATEGY_LIST.map((s) => [s.name, s]));
+
+export function getStrategy(name) {
+  const s = STRATEGIES[name];
+  if (!s) throw new Error(`Unknown strategy: ${name}`);
+  return s;
+}

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -41,14 +41,18 @@ export class HUD {
       const select = document.createElement("select");
       select.className = "strat-select";
       for (const name of Object.keys(STRATEGIES)) {
+        const strat = STRATEGIES[name];
         const opt = document.createElement("option");
         opt.value = name;
         opt.textContent = name;
-        if (player.strategy === STRATEGIES[name]) opt.selected = true;
+        if (strat.description) opt.title = strat.description;
+        if (player.strategy === strat) opt.selected = true;
         select.appendChild(opt);
       }
+      if (player.strategy?.description) select.title = player.strategy.description;
       select.addEventListener("change", () => {
         player.strategy = STRATEGIES[select.value];
+        select.title = player.strategy?.description ?? "";
       });
 
       const bar = document.createElement("div");

--- a/tournament/arena.js
+++ b/tournament/arena.js
@@ -1,0 +1,84 @@
+// Headless single-match runner. Returns a structured result with rankings.
+import { Game } from "../src/core/Game.js";
+import { Player } from "../src/core/Player.js";
+
+const PALETTE = [
+  { color: "#ff4d6d", accent: "#ff8fa3" },
+  { color: "#3ea6ff", accent: "#8ecbff" },
+  { color: "#a16bff", accent: "#cdb4ff" },
+  { color: "#52e0a4", accent: "#a8f3d2" },
+  { color: "#ffb84d", accent: "#ffd699" },
+  { color: "#f97aff", accent: "#fbc2ff" },
+  { color: "#ffe066", accent: "#fff3a3" },
+  { color: "#7cffb2", accent: "#bbffd6" },
+];
+
+export function runMatch({
+  strategies,
+  mapConfig,
+  startPositions,
+  seed = 1,
+  maxTicks = 4000,
+  tickInterval = 1 / 30,
+}) {
+  if (strategies.length !== startPositions.length) {
+    throw new Error(`runMatch: ${strategies.length} strategies but ${startPositions.length} positions`);
+  }
+
+  const game = new Game({ ...mapConfig, seed, maxHistory: 0 });
+  const players = strategies.map((s, i) => {
+    const palette = PALETTE[i % PALETTE.length];
+    return new Player({
+      name: `${s.name}#${i + 1}`,
+      color: palette.color,
+      accent: palette.accent,
+      strategy: s,
+    });
+  });
+  players.forEach((p) => game.addPlayer(p));
+  startPositions.forEach((pos, i) => {
+    game.placeArmy({ x: pos.x, y: pos.y, player: players[i], strength: pos.strength ?? 1 });
+  });
+
+  const eliminated = new Map(); // playerId -> tick
+  let endReason = "max-ticks";
+  while (game.tick < maxTicks) {
+    game.step(tickInterval);
+    const alive = new Set(game.livingPlayers().map((p) => p.id));
+    for (const p of players) {
+      if (!alive.has(p.id) && !eliminated.has(p.id)) eliminated.set(p.id, game.tick);
+    }
+    if (alive.size <= 1) {
+      endReason = alive.size === 1 ? "winner" : "mutual-destruction";
+      break;
+    }
+  }
+
+  // Territory totals are dirty-flagged during step(); refresh for the final
+  // ranking.
+  game.recomputeTerritory();
+
+  // Ranking: late deaths beat early deaths; among survivors, more territory wins.
+  const ranked = [...players].sort((a, b) => {
+    const aDied = eliminated.get(a.id) ?? Infinity;
+    const bDied = eliminated.get(b.id) ?? Infinity;
+    if (aDied !== bDied) return bDied - aDied;
+    if (a.totals.territory !== b.totals.territory) return b.totals.territory - a.totals.territory;
+    return b.totals.strength - a.totals.strength;
+  });
+
+  return {
+    seed,
+    ticks: game.tick,
+    endReason,
+    ranking: ranked.map((p) => ({
+      strategy: p.strategy.name,
+      slot: players.indexOf(p),
+      territory: p.totals.territory,
+      strength: +p.totals.strength.toFixed(2),
+      armies: p.totals.armies,
+      eliminatedAt: eliminated.get(p.id) ?? null,
+      survived: !eliminated.has(p.id),
+    })),
+  };
+}

--- a/tournament/maps.js
+++ b/tournament/maps.js
@@ -1,0 +1,44 @@
+// Map presets used by the tournament runner. Each preset is map config + a
+// function that returns starting positions for `n` players.
+
+function ringPositions(n, { width, height, radiusFactor = 0.4, edgePad = 1 }) {
+  const cx = width / 2;
+  const cy = height / 2;
+  const r = Math.min(width, height) * radiusFactor;
+  const pad = edgePad;
+  const positions = [];
+  for (let i = 0; i < n; i++) {
+    const angle = (i / n) * Math.PI * 2;
+    const x = clamp(Math.floor(cx + Math.cos(angle) * r), pad, width - 1 - pad);
+    const y = clamp(Math.floor(cy + Math.sin(angle) * r), pad, height - 1 - pad);
+    positions.push({ x, y, strength: 1 });
+  }
+  return positions;
+}
+
+function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export const MAPS = {
+  arena: {
+    name: "arena",
+    config: { width: 30, height: 22, growth: 2, maxArmy: 12, wrap: true },
+    positions: (n) => ringPositions(n, { width: 30, height: 22, radiusFactor: 0.4 }),
+  },
+  classic: {
+    name: "classic",
+    config: { width: 40, height: 30, growth: 1, maxArmy: 10, wrap: true },
+    positions: (n) => ringPositions(n, { width: 40, height: 30, radiusFactor: 0.42 }),
+  },
+  royale: {
+    name: "royale",
+    config: { width: 44, height: 32, growth: 1.2, maxArmy: 10, wrap: false },
+    positions: (n) => ringPositions(n, { width: 44, height: 32, radiusFactor: 0.45, edgePad: 2 }),
+  },
+  tight: {
+    name: "tight",
+    config: { width: 22, height: 16, growth: 2.2, maxArmy: 12, wrap: true },
+    positions: (n) => ringPositions(n, { width: 22, height: 16, radiusFactor: 0.38 }),
+  },
+};

--- a/tournament/run.js
+++ b/tournament/run.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// CLI entrypoint: run a headless tournament between bot strategies.
+//
+//   node tournament/run.js                              # all strategies, arena, 10 rounds
+//   node tournament/run.js --bots Aggressive,Trinity    # just these two
+//   node tournament/run.js --map royale --rounds 50     # different map / more rounds
+//   node tournament/run.js --list                       # print available strategies
+//   node tournament/run.js --help
+
+import { STRATEGY_LIST, getStrategy } from "../src/strategies/index.js";
+import { MAPS } from "./maps.js";
+import { runTournament } from "./scheduler.js";
+
+const HELP = `Usage: node tournament/run.js [options]
+
+Options:
+  --bots A,B,C     Comma-separated strategy names (default: all)
+  --map NAME       Map preset: ${Object.keys(MAPS).join(", ")} (default: arena)
+  --rounds N       Number of matches to run (default: 10)
+  --ticks N        Max ticks per match (default: 4000)
+  --seed N         Base seed; round R uses seed+R (default: 1)
+  --json           Emit standings as JSON (skip the table)
+  --verbose        Print per-match results
+  --list           List available strategies and exit
+  --help           Show this help
+`;
+
+function parseArgs(argv) {
+  const opts = {
+    bots: null,
+    map: "arena",
+    rounds: 10,
+    ticks: 4000,
+    seed: 1,
+    json: false,
+    verbose: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--bots": opts.bots = next().split(",").map((s) => s.trim()).filter(Boolean); break;
+      case "--map": opts.map = next(); break;
+      case "--rounds": opts.rounds = parseInt(next(), 10); break;
+      case "--ticks": opts.ticks = parseInt(next(), 10); break;
+      case "--seed": opts.seed = parseInt(next(), 10); break;
+      case "--json": opts.json = true; break;
+      case "--verbose": case "-v": opts.verbose = true; break;
+      case "--list":
+        console.log(STRATEGY_LIST.map((s) => `${s.name.padEnd(18)} ${s.description ?? ""}`).join("\n"));
+        process.exit(0);
+      case "--help": case "-h":
+        console.log(HELP);
+        process.exit(0);
+      default:
+        console.error(`Unknown option: ${a}`);
+        console.error(HELP);
+        process.exit(1);
+    }
+  }
+  return opts;
+}
+
+function pad(s, n, right = false) {
+  s = String(s);
+  return right ? s.padStart(n) : s.padEnd(n);
+}
+
+function printTable(standings, meta) {
+  console.log(`\nFinal standings · map=${meta.map} · rounds=${meta.rounds} · maxTicks=${meta.ticks} · seed=${meta.seed}`);
+  console.log(
+    `${pad("#", 4)}  ${pad("Strategy", 18)}  ${pad("Pts", 5, true)}  ${pad("Wins", 5, true)}  ${pad("Win%", 6, true)}  ${pad("AvgRank", 8, true)}  ${pad("AvgTerr", 8, true)}  ${pad("Survive%", 9, true)}`,
+  );
+  console.log("-".repeat(78));
+  standings.forEach((s, i) => {
+    console.log(
+      `${pad(i + 1, 4)}  ${pad(s.name, 18)}  ${pad(s.points, 5, true)}  ${pad(s.wins, 5, true)}  ${pad((s.winRate * 100).toFixed(1) + "%", 6, true)}  ${pad(s.avgRank.toFixed(2), 8, true)}  ${pad(s.avgTerritory.toFixed(1), 8, true)}  ${pad((s.survivalRate * 100).toFixed(1) + "%", 9, true)}`,
+    );
+  });
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const map = MAPS[opts.map];
+  if (!map) {
+    console.error(`Unknown map: ${opts.map}. Choose from: ${Object.keys(MAPS).join(", ")}`);
+    process.exit(1);
+  }
+
+  const names = opts.bots ?? STRATEGY_LIST.map((s) => s.name);
+  let strategies;
+  try {
+    strategies = names.map(getStrategy);
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+  if (strategies.length < 2) {
+    console.error("Need at least 2 strategies. Use --list to see options.");
+    process.exit(1);
+  }
+
+  const onMatch = opts.verbose
+    ? (round, result) => {
+        console.log(`Round ${round + 1} · seed=${result.seed} · ticks=${result.ticks} · ${result.endReason}`);
+        result.ranking.forEach((r, i) => {
+          const tag = r.survived ? "alive" : `eliminated@${r.eliminatedAt}`;
+          console.log(`  ${i + 1}. ${r.strategy.padEnd(18)} terr=${String(r.territory).padStart(4)} str=${String(r.strength).padStart(6)} (${tag})`);
+        });
+      }
+    : null;
+
+  const { standings, results } = runTournament({
+    strategies,
+    map,
+    rounds: opts.rounds,
+    baseSeed: opts.seed,
+    maxTicks: opts.ticks,
+    onMatch,
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify({ meta: { map: opts.map, rounds: opts.rounds, ticks: opts.ticks, seed: opts.seed }, standings, results }, null, 2) + "\n");
+    return;
+  }
+
+  printTable(standings, { map: opts.map, rounds: opts.rounds, ticks: opts.ticks, seed: opts.seed });
+}
+
+main();

--- a/tournament/scheduler.js
+++ b/tournament/scheduler.js
@@ -1,0 +1,80 @@
+// Round-robin / FFA tournament scheduler.
+import { runMatch } from "./arena.js";
+
+export function runTournament({
+  strategies,
+  map,
+  rounds = 10,
+  baseSeed = 1,
+  maxTicks = 4000,
+  onMatch = null,
+}) {
+  const N = strategies.length;
+  if (N < 2) throw new Error("Need at least 2 strategies");
+
+  const standings = new Map();
+  for (const s of strategies) {
+    standings.set(s.name, {
+      name: s.name,
+      author: s.author ?? "",
+      played: 0,
+      wins: 0,
+      survived: 0,
+      points: 0,
+      totalRank: 0,
+      totalTerritory: 0,
+      totalEliminationTick: 0,
+      eliminationCount: 0,
+    });
+  }
+
+  const positions = map.positions(N);
+  const results = [];
+
+  for (let round = 0; round < rounds; round++) {
+    // Rotate strategy -> slot mapping so each strategy visits each starting
+    // position across rounds, removing positional bias.
+    const offset = round % N;
+    const lineup = strategies.map((_, i) => strategies[(i + offset) % N]);
+    const seed = baseSeed + round;
+
+    const result = runMatch({
+      strategies: lineup,
+      mapConfig: map.config,
+      startPositions: positions,
+      seed,
+      maxTicks,
+    });
+
+    onMatch?.(round, result, lineup);
+    results.push({ round, seed, lineup: lineup.map((s) => s.name), ...result });
+
+    for (let i = 0; i < result.ranking.length; i++) {
+      const r = result.ranking[i];
+      const s = standings.get(r.strategy);
+      s.played++;
+      s.totalRank += i + 1;
+      s.points += N - 1 - i; // Borda
+      s.totalTerritory += r.territory;
+      if (r.survived) s.survived++;
+      if (i === 0 && r.survived) s.wins++;
+      if (r.eliminatedAt != null) {
+        s.totalEliminationTick += r.eliminatedAt;
+        s.eliminationCount++;
+      }
+    }
+  }
+
+  const sorted = [...standings.values()]
+    .map((s) => ({
+      ...s,
+      avgRank: s.played ? s.totalRank / s.played : 0,
+      avgTerritory: s.played ? s.totalTerritory / s.played : 0,
+      avgEliminationTick: s.eliminationCount ? s.totalEliminationTick / s.eliminationCount : null,
+      winRate: s.played ? s.wins / s.played : 0,
+      survivalRate: s.played ? s.survived / s.played : 0,
+    }))
+    .sort((a, b) => b.points - a.points || a.avgRank - b.avgRank);
+
+  return { standings: sorted, results };
+}


### PR DESCRIPTION
## Summary

This PR refactors the monolithic strategy index into individual module files, adds a deterministic RNG system, and introduces a complete headless tournament runner for bot competitions.

## Key Changes

**Strategy Modularization**
- Split `src/strategies/index.js` from 198 lines into 9 individual strategy files (one per bot)
- Each strategy now exports a metadata object with `name`, `author`, `version`, `description`, and `act(army, game)` function
- Created `src/strategies/helpers.js` with shared `balanceAttack()` utility
- Updated registry to use `STRATEGY_LIST` array and `getStrategy(name)` lookup function

**Deterministic RNG**
- Added `src/core/rng.js` with Mulberry32 PRNG implementation
- `Game` constructor now accepts optional `seed` parameter
- All bots updated to use `game.rng()` instead of `Math.random()` for reproducible tournaments
- Fallback to `Math.random()` when seed is null (browser mode)

**Tournament Infrastructure**
- `tournament/arena.js`: Headless single-match runner with structured result ranking
- `tournament/scheduler.js`: Round-robin tournament scheduler with Borda scoring
- `tournament/maps.js`: Map presets (arena, classic, royale, tight) with configurable starting positions
- `tournament/run.js`: CLI entrypoint with options for bot selection, map, rounds, seed, and output formats

**Documentation & Configuration**
- `docs/strategies.md`: Comprehensive bot-author guide covering file layout, API contract, determinism, and tournament usage
- `package.json`: Added with npm scripts (`tournament`, `serve`) and Node 19+ requirement
- Updated `README.md` with tournament instructions and architecture overview

**Core Updates**
- `src/core/Game.js`: Integrated RNG system and seed parameter
- `src/core/Army.js`: Updated to call strategy as object method (`strat.act()`) instead of function
- `src/ui/HUD.js`: Updated strategy dropdown to work with new metadata structure

## Notable Implementation Details

- Strategies are now first-class objects with metadata, enabling better discoverability and documentation
- Tournament ranking uses Borda scoring with tiebreakers: survival > elimination tick > territory > strength
- Starting positions rotate across rounds to eliminate positional bias
- Matches are fully reproducible via seed parameter—same seed always produces identical outcomes
- CLI supports JSON output for programmatic result processing

https://claude.ai/code/session_0199Ctt8rKfp1rk7KMKgWhYh