### PR TITLE
Implement dirty flag rendering to reduce unnecessary redraws

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,9 @@ class App {
     this.lastFrame = performance.now();
     this.tickAccumulator = 0;
     this.tickInterval = 1 / 30;
+    this.renderInterval = 200;
+    this.lastRender = 0;
+    this._needsRender = true;
     this.activePlayer = null;
     this.lastWinnerLogged = null;
 
@@ -73,6 +76,7 @@ class App {
     this.bindCanvas();
     this.playing = true;
     this.controls.setPlaying(true);
+    this.markDirty();
   }
 
   bindCanvas() {
@@ -80,9 +84,11 @@ class App {
     this._canvasBound = true;
     this.canvas.addEventListener("mousemove", (e) => {
       this.renderer.hoverTile = this.renderer.pixelToTile(e.clientX, e.clientY);
+      this.markDirty();
     });
     this.canvas.addEventListener("mouseleave", () => {
       this.renderer.hoverTile = null;
+      this.markDirty();
     });
     this.canvas.addEventListener("click", (e) => {
       const tile = this.renderer.pixelToTile(e.clientX, e.clientY);
@@ -92,25 +98,33 @@ class App {
         this.game.placeArmy({ x: tile.pos.x, y: tile.pos.y, player: this.activePlayer, strength: 2 });
         this.controls.log(`Spawned ${this.activePlayer.name} army at (${tile.pos.x}, ${tile.pos.y})`);
       }
+      this.markDirty();
     });
   }
 
   setActivePlayer(player) {
     this.activePlayer = player;
     this.hud.update();
+    this.markDirty();
   }
 
   togglePlay() {
     this.playing = !this.playing;
     this.controls.setPlaying(this.playing);
+    this.markDirty();
   }
 
   stepOnce() {
     this.game.step(this.tickInterval);
+    this.markDirty();
   }
 
   reload() {
     this.loadMode(this.modeKey);
+  }
+
+  markDirty() {
+    this._needsRender = true;
   }
 
   startLoop() {
@@ -125,11 +139,17 @@ class App {
           this.tickAccumulator -= this.tickInterval;
         }
       }
-      this.game.recomputeTerritory();
-      this.renderer.draw(now);
-      this.chart.draw();
-      this.hud.update();
-      this.controls.setTick(this.game.tick);
+      const shouldRender =
+        this._needsRender || (this.playing && now - this.lastRender >= this.renderInterval);
+      if (shouldRender) {
+        if (this.game._territoryDirty) this.game.recomputeTerritory();
+        this.renderer.draw(now);
+        this.chart.draw();
+        this.hud.update();
+        this.controls.setTick(this.game.tick);
+        this.lastRender = now;
+        this._needsRender = false;
+      }
       this.checkWinner();
       requestAnimationFrame(loop);
     };

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -28,12 +28,15 @@ export class Controls {
     this.modeSelect.addEventListener("change", () => this.app.loadMode(this.modeSelect.value));
     this.toggleGrid.addEventListener("change", () => {
       this.app.renderer.showGrid = this.toggleGrid.checked;
+      this.app.markDirty();
     });
     this.toggleTerritory.addEventListener("change", () => {
       this.app.renderer.showTerritory = this.toggleTerritory.checked;
+      this.app.markDirty();
     });
     this.toggleGlow.addEventListener("change", () => {
       this.app.renderer.showGlow = this.toggleGlow.checked;
+      this.app.markDirty();
     });
 
     document.addEventListener("keydown", (e) => {


### PR DESCRIPTION
## Summary
This PR implements a dirty flag-based rendering system to optimize performance by reducing unnecessary redraws. Instead of rendering every frame, the app now only renders when the state has changed or at a throttled interval during active gameplay.

## Key Changes
- Added `_needsRender`, `renderInterval`, and `lastRender` properties to track render state and throttle rendering
- Introduced `markDirty()` method to flag when a redraw is needed
- Modified the main game loop to conditionally render based on:
  - Whether the dirty flag is set (immediate render on state changes)
  - Whether the game is playing and enough time has passed (throttled rendering at 200ms intervals)
- Added `markDirty()` calls throughout the codebase:
  - User interactions (canvas events, button clicks)
  - Game state changes (active player, play/pause, step)
  - Renderer settings changes (grid, territory, glow toggles)
- Deferred `game.recomputeTerritory()` to only run when actually rendering and when the territory is marked dirty

## Implementation Details
- The render throttle interval is set to 200ms during active gameplay, reducing CPU usage while maintaining responsive visual feedback
- State changes immediately trigger a render on the next frame, ensuring the UI stays responsive to user input
- The dirty flag is reset after each render to prevent redundant redraws

https://claude.ai/code/session_01Luya2xrryHcgBXUTTFLCpc