### PR TITLE
Add strategy summaries documenting design rationale and tradeoffs

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -16,11 +16,22 @@ export default {
   author: "shady",        // freeform
   version: 1,
   description: "Always misses, but with great enthusiasm.",
+  summary: `Optional. Free-text thesis / design notes for human readers.
+Explain *why* the bot plays the way it does, what matchups you expect
+it to win or lose, and any tunables a future reader might want to
+revisit. Multi-line template literals are fine.`,
   act(army, game) {
     // your logic here
   },
 };
 ```
+
+`description` is the one-line tooltip shown in the HUD and tournament
+listing; `summary` is the long form you'd write in a commit message — a
+thesis, rationale, known weaknesses, anything that helps the next reader
+understand the design. Nothing in the engine reads `summary`; it is
+documentation that lives next to the code that implements it. See the
+core bots in `src/strategies/` for examples.
 
 Then add it to the registry list in `src/strategies/index.js`:
 

--- a/src/strategies/Aggressive.js
+++ b/src/strategies/Aggressive.js
@@ -5,6 +5,16 @@ export default {
   author: "core",
   version: 1,
   description: "Picks the strongest enemy it can still beat; otherwise plays SlowAndSteady.",
+  summary: `Greedy on contact. When at least one neighbor has enemies, pick
+the *strongest* enemy stack we can still beat with margin (their total <
+our strength - 1) and commit strength - 1 into it. The intuition: SlowAndSteady
+will happily punch the weakest enemy first, but the weakest enemy is
+usually irrelevant — taking out the biggest threat we can afford to take
+out swings the board harder. With no enemies adjacent, we fall back to
+SlowAndSteady so we don't sit idle in our own backfield. Weakness: the
+"can I beat them with margin 1" check is local and ignores enemy
+reinforcements arriving the same tick, so this bot occasionally walks
+into trades it expected to win.`,
   act(army, game) {
     const neighbors = army.tile ? army.tile.neighbors : null;
     const pid = army.player.id;

--- a/src/strategies/Berserker.js
+++ b/src/strategies/Berserker.js
@@ -3,6 +3,12 @@ export default {
   author: "core",
   version: 1,
   description: "Throws everything in a random direction every tick.",
+  summary: `Random's louder cousin. Same chaotic direction pick, but always
+commits strength - 1 instead of a random force. Thesis: in early-game
+chaos, decisively dumping mass somewhere — anywhere — beats hesitating,
+because thin armies are food. Performs surprisingly well against
+Cautious and Defender, which need contact to convert their advantages,
+and predictably gets dismantled by Trinity once Trinity's lines form.`,
   act(army, game) {
     if (army.strength < 2) return;
     const dir = (game.rng() * 4) | 0;

--- a/src/strategies/Cautious.js
+++ b/src/strategies/Cautious.js
@@ -5,6 +5,14 @@ export default {
   author: "core",
   version: 1,
   description: "Sits on its hands until well above 70% strength, then plays SlowAndSteady.",
+  summary: `Tax the impatient. Skip every tick until we are above 70% of
+maxStrength, then act like SlowAndSteady. Idea: armies regenerate
+passively, and a tile with three full-strength armies on it is worth
+more than three half-strength armies spread across three tiles. By
+refusing to move thin, we always engage from a position of strength.
+The risk is being caught flat-footed — if a Berserker or Aggressive
+neighbor commits to us before we cross the threshold, we eat the
+attack without responding.`,
   act(army, game) {
     if (army.strength < army.maxStrength * 0.7) return;
     SlowAndSteady.act(army, game);

--- a/src/strategies/Defender.js
+++ b/src/strategies/Defender.js
@@ -5,6 +5,15 @@ export default {
   author: "core",
   version: 1,
   description: "Reinforces the friendliest neighbor; expands only when nearly full.",
+  summary: `Turtle. Each army looks at its four neighbors and counts how many
+friendlies sit on each; whichever tile has the most friendlies gets half
+our strength as reinforcement (provided we have at least 4 to spare).
+The hypothesis is that PixelWars rewards thick stacks over wide thin
+fronts — once a tile has 3+ friendly armies it is essentially
+unbreakable to a single attacker. We only expand (via SlowAndSteady)
+when over 85% of maxStrength, so most ticks we just thicken. This bot
+loses to anyone who can starve us of contact, but it is very hard to
+kill in a head-on brawl.`,
   act(army, game) {
     const neighbors = army.tile ? army.tile.neighbors : null;
     const pid = army.player.id;

--- a/src/strategies/Random.js
+++ b/src/strategies/Random.js
@@ -3,6 +3,10 @@ export default {
   author: "core",
   version: 1,
   description: "Random direction, random force. Pure chaos.",
+  summary: `Control bot. The point of Random is to be the noise floor — any
+strategy that can't reliably outscore Random is doing something
+actively wrong. Uses game.rng() rather than Math.random() so tournament
+runs replay deterministically.`,
   act(army, game) {
     const dir = (game.rng() * 4) | 0;
     const tile = army.tile ? army.tile.neighbors[dir] : game.map.adjacent(army.pos, dir);

--- a/src/strategies/Repel.js
+++ b/src/strategies/Repel.js
@@ -7,6 +7,13 @@ export default {
   author: "core",
   version: 1,
   description: "Like SlowAndSteady, but biases movement away from the home corner.",
+  summary: `SlowAndSteady's problem on corner spawns is that "weakest neighbor"
+often points back into our own dense interior, so we cannibalize friendly
+stacks instead of expanding. Repel injects a fixed gradient (push east and
+south, pull away from west and north) so ties break outward. The number
+3 on south is deliberately a bit larger than 2 on east — the home corner
+in the standard maps sits NW, so south and east are the two productive
+directions but south has more open ground before contact.`,
   act(army) {
     const tile = army.weakestAdjacent(GRADIENT);
     if (!tile) return;

--- a/src/strategies/SlowAndSteady.js
+++ b/src/strategies/SlowAndSteady.js
@@ -5,6 +5,13 @@ export default {
   author: "core",
   version: 1,
   description: "Always splits toward the weakest neighbor with a balanced attack.",
+  summary: `The baseline. Every tick, send the minimum force needed to take or
+reinforce the weakest adjacent tile, and keep the rest behind. The thesis is
+that controlled, low-variance pressure beats burst aggression in the long
+run: balanceAttack rarely overcommits, so we don't strand a fat army
+adjacent to a tile we can't quite hold. Most of the other core bots use
+SlowAndSteady as a fallback because in the absence of a better idea it is
+hard to do worse.`,
   act(army) {
     const tile = army.weakestAdjacent();
     if (!tile) return;

--- a/src/strategies/Swarm.js
+++ b/src/strategies/Swarm.js
@@ -3,6 +3,15 @@ export default {
   author: "core",
   version: 1,
   description: "Sends small probes toward weak enemies, preferring lonely tiles.",
+  summary: `Probe-and-spread. Each army scores neighbors as enemyStrength -
+0.5 * friendlyCount and picks the lowest-scoring tile that we can still
+overpower (enemyS < strength - 0.5). It commits about 40% of strength
+into the probe, never the whole army. Thesis: territory is scored by
+tile count, not stack count, so it pays to seed the map with cheap
+controlling armies rather than walk one big stack across it. The
+friendlyCount bonus is a small repulsion: prefer lonely tiles so we
+don't pile onto territory we already own. Brittle against Aggressive,
+which preys on the half-strength remainders we leave behind.`,
   act(army, game) {
     const neighbors = army.tile ? army.tile.neighbors : null;
     const pid = army.player.id;

--- a/src/strategies/Trinity.js
+++ b/src/strategies/Trinity.js
@@ -49,6 +49,16 @@ export default {
   author: "core",
   version: 1,
   description: "Convolves friendly density with three-in-a-row kernels and pushes that way.",
+  summary: `Thesis: in PixelWars, three friendlies in a line is structurally
+strong — the middle tile gets reinforced from both sides while the ends
+project pressure forward. So instead of looking at immediate neighbors,
+each army inspects its 5x5 stencil and runs four diagonal "knight-ish"
+kernels that score how much friendly mass would be aligned with it if it
+moved in each cardinal direction. Pick the direction with the best
+alignment score and shove almost everything (strength - 1) that way. This
+makes Trinity behave like a flocking bot without any explicit
+communication between armies — the alignment is emergent from each army
+independently optimizing the same convolution.`,
   act(army) {
     const tile = army.tile;
     if (!tile) return;


### PR DESCRIPTION
## Summary
This PR adds comprehensive `summary` fields to all core bot strategies, documenting the design philosophy, tactical approach, and known weaknesses of each strategy. These summaries serve as living documentation for future readers and maintainers.

## Changes
- **docs/strategies.md**: Added documentation explaining the distinction between `description` (one-line HUD tooltip) and `summary` (long-form design rationale)
- **All core strategies** (`Aggressive`, `Trinity`, `Defender`, `Swarm`, `Cautious`, `Repel`, `SlowAndSteady`, `Berserker`, `Random`): Added `summary` field with:
  - Core thesis and strategic intent
  - Tactical mechanics and decision-making logic
  - Known weaknesses and failure modes
  - Matchup insights where relevant

## Implementation Details
- Summaries use multi-line template literals for readability
- Each summary explains *why* the bot plays the way it does, not just *what* it does
- Documented tradeoffs help future readers understand design decisions and potential improvements
- The `summary` field is purely documentation—the engine does not read or use it
- Examples provided in core strategies serve as templates for community-contributed bots

https://claude.ai/code/session_01HCWmp3WrbuZNMi89njLWp6