### PR TITLE
Add parameterized bot factory and 100 generated strategies

### DIFF
--- a/src/strategies/factory.js
+++ b/src/strategies/factory.js
@@ -62,6 +62,7 @@ export function makeBot(cfg) {
     forceAbsolute = null,
     pickMode = "min",
     fallbackName = null,
+    summary = "",
   } = cfg;
 
   return {
@@ -69,6 +70,7 @@ export function makeBot(cfg) {
     description,
     author,
     version: 1,
+    summary,
     act(army, game) {
       if (army.strength < minStrengthAbs) return;
       if (minStrengthFrac > 0 && army.strength < army.maxStrength * minStrengthFrac) return;
@@ -150,6 +152,7 @@ export function makeStencilBot(cfg) {
     forceFrac = 1.0,
     forceMode = "frac",
     fallbackName = null,
+    summary = "",
   } = cfg;
 
   const OFFSETS = kernels.map((k) => {
@@ -168,6 +171,7 @@ export function makeStencilBot(cfg) {
     description,
     author,
     version: 1,
+    summary,
     act(army, game) {
       const tile = army.tile;
       if (!tile) return;

--- a/src/strategies/factory.js
+++ b/src/strategies/factory.js
@@ -1,0 +1,206 @@
+// Parameterized bot factories. Each call to makeBot / makeStencilBot returns
+// a strategy object with the standard { name, act } shape. Designed so that
+// many distinct, named bots can be expressed as plain config objects.
+//
+// makeBot models a "scan-the-four-neighbors-and-pick-one" loop. A bot is
+// described by:
+//
+//   - activation gates (min strength absolute / fractional, tick gating)
+//   - per-neighbor scoring weights (enemy strength, friendly count, gradient,
+//     bonuses for empty/owned tiles)
+//   - eligibility filters (must be winnable, must contain enemy, must be
+//     empty, must not be friendly)
+//   - selection mode ("min" picks lowest score, "max" picks highest)
+//   - commitment mode ("frac" = forceFrac of (s-1), "all" = s-1,
+//     "balance" = balanceAttack helper, "absolute" = forceAbsolute units)
+//   - fallback when no neighbor passes filters ("slow", "balance",
+//     "berserk", "wait")
+//
+// makeStencilBot picks one of four directions by convolving four 5x5 kernels
+// against the tile's stencil, mirroring Trinity. The kernel index is also
+// the chosen direction, so author kernels with that mapping in mind.
+
+import { balanceAttack } from "./helpers.js";
+import { sumStrength } from "../core/Army.js";
+
+function applyFallback(name, army, game) {
+  if (!name || name === "wait") return;
+  if (name === "slow" || name === "balance") {
+    const t = army.weakestAdjacent();
+    if (t) balanceAttack(army, t);
+    return;
+  }
+  if (name === "berserk") {
+    if (army.strength < 2) return;
+    const dir = (game.rng() * 4) | 0;
+    const tile = army.tile ? army.tile.neighbors[dir] : null;
+    if (tile) army.attack(tile, army.strength - 1);
+  }
+}
+
+export function makeBot(cfg) {
+  const {
+    name,
+    description = "",
+    author = "factory",
+    minStrengthAbs = 1.5,
+    minStrengthFrac = 0,
+    tickPeriod = 1,
+    tickPhase = 0,
+    weightEnemy = 1,
+    weightFriendly = 0,
+    weightEmptyBonus = 0,
+    weightOwnedBonus = 0,
+    gradient = null,
+    requireWinnable = false,
+    requireEnemy = false,
+    requireEmpty = false,
+    avoidFriendly = false,
+    forceFrac = 1.0,
+    forceMinPower = 1.5,
+    forceMode = "frac",
+    forceAbsolute = null,
+    pickMode = "min",
+    fallbackName = null,
+  } = cfg;
+
+  return {
+    name,
+    description,
+    author,
+    version: 1,
+    act(army, game) {
+      if (army.strength < minStrengthAbs) return;
+      if (minStrengthFrac > 0 && army.strength < army.maxStrength * minStrengthFrac) return;
+      if (tickPeriod > 1 && (game.tick % tickPeriod) !== tickPhase) return;
+
+      const tile = army.tile;
+      if (!tile) return;
+      const neighbors = tile.neighbors;
+      const pid = army.player.id;
+
+      let best = null;
+      let bestScore = pickMode === "max" ? -Infinity : Infinity;
+
+      for (let i = 0; i < 4; i++) {
+        const t = neighbors[i];
+        if (!t) continue;
+        const armies = t.armies;
+        let enemyS = 0;
+        let friendly = 0;
+        for (let k = 0; k < armies.length; k++) {
+          const a = armies[k];
+          if (a.player.id === pid) friendly++;
+          else enemyS += a.strength;
+        }
+        const owned = friendly > 0;
+        const isEmpty = armies.length === 0;
+
+        if (requireEnemy && enemyS === 0) continue;
+        if (requireEmpty && !isEmpty) continue;
+        if (requireWinnable && enemyS + 1 >= army.strength) continue;
+        if (avoidFriendly && owned) continue;
+
+        let score = weightEnemy * enemyS - weightFriendly * friendly;
+        if (isEmpty) score -= weightEmptyBonus;
+        if (owned) score -= weightOwnedBonus;
+        if (gradient) score -= gradient[i];
+
+        if (pickMode === "max") {
+          if (score > bestScore) { bestScore = score; best = t; }
+        } else {
+          if (score < bestScore) { bestScore = score; best = t; }
+        }
+      }
+
+      if (!best) {
+        applyFallback(fallbackName, army, game);
+        return;
+      }
+
+      if (forceMode === "balance") {
+        balanceAttack(army, best);
+        return;
+      }
+
+      let power;
+      if (forceMode === "all") {
+        power = army.strength - 1;
+      } else if (forceMode === "absolute" && forceAbsolute != null) {
+        power = forceAbsolute;
+      } else {
+        power = (army.strength - 1) * forceFrac;
+      }
+      if (power < forceMinPower) power = forceMinPower;
+      const cap = army.strength - 1;
+      if (power > cap) power = cap;
+      if (power <= 0.6) return;
+      army.attack(best, power);
+    },
+  };
+}
+
+// Stencil bot: four 5x5 kernels, kernel index k <=> direction k (W,E,N,S).
+export function makeStencilBot(cfg) {
+  const {
+    name,
+    description = "",
+    author = "factory",
+    kernels,
+    forceFrac = 1.0,
+    forceMode = "frac",
+    fallbackName = null,
+  } = cfg;
+
+  const OFFSETS = kernels.map((k) => {
+    const out = [];
+    for (let i = 0; i < 5; i++) {
+      for (let j = 0; j < 5; j++) {
+        const w = k[i][j];
+        if (w !== 0) out.push(i * 5 + j, w);
+      }
+    }
+    return out;
+  });
+
+  return {
+    name,
+    description,
+    author,
+    version: 1,
+    act(army, game) {
+      const tile = army.tile;
+      if (!tile) return;
+      const stencil = tile.stencil5;
+      const viewer = army.player;
+
+      let bestDir = -1;
+      let bestScore = -Infinity;
+      for (let k = 0; k < OFFSETS.length; k++) {
+        const offs = OFFSETS[k];
+        let score = 0;
+        for (let n = 0; n < offs.length; n += 2) {
+          const t = stencil[offs[n]];
+          if (!t) continue;
+          score += offs[n + 1] * sumStrength(t.armies, viewer);
+        }
+        if (score > bestScore) { bestScore = score; bestDir = k; }
+      }
+
+      const target = bestDir >= 0 ? tile.neighbors[bestDir] : null;
+      if (!target) {
+        applyFallback(fallbackName, army, game);
+        return;
+      }
+
+      let power;
+      if (forceMode === "all") power = army.strength - 1;
+      else power = (army.strength - 1) * forceFrac;
+      if (power < 1.5) {
+        applyFallback(fallbackName, army, game);
+        return;
+      }
+      army.attack(target, power);
+    },
+  };
+}

--- a/src/strategies/generated.js
+++ b/src/strategies/generated.js
@@ -11,69 +11,106 @@
 //   Scatter_*     refuse to land on friendly tiles; vary target preference
 //   Pulse_*       only act on a tick cadence (period & phase)
 //   Stencil_*     pick direction by convolving 5x5 kernels (Trinity-style)
+//
+// Each bot carries a `summary` describing its family's thesis with the
+// specific bot's parameters spliced in. See docs/strategies.md for the
+// distinction between `description` (HUD one-liner) and `summary`.
 
 import { makeBot, makeStencilBot } from "./factory.js";
 
 const pad2 = (n) => String(n).padStart(2, "0");
 
+// ---------------------------------------------------------------- Hunters
 const HUNTERS = [];
 for (let i = 1; i <= 10; i++) {
   const frac = i / 10;
+  const pct = Math.round(frac * 100);
   HUNTERS.push(makeBot({
     name: `Hunter_${pad2(i)}`,
-    description: `Targets weakest beatable enemy; commits ${Math.round(frac * 100)}% of force.`,
+    description: `Targets weakest beatable enemy; commits ${pct}% of force.`,
     requireEnemy: true,
     requireWinnable: true,
     forceFrac: frac,
     fallbackName: "slow",
+    summary: `Hunter family. Greedy on contact: only considers neighbors that
+contain enemies AND that we can beat with margin (their total < our
+strength - 1). Among those, picks the WEAKEST so we are guaranteed a clean
+take. Commitment fraction here is ${pct}% of (strength - 1); low fractions
+let us keep biting smaller stacks tick after tick, while higher fractions
+front-load the win and leave less behind. With no winnable enemy adjacent,
+we fall back to SlowAndSteady so we never sit idle. Expected to do well
+against bots that bunch up and badly against Pacifists who never present
+an attackable target.`,
   }));
 }
 
+// ----------------------------------------------------------------- Probes
 const PROBES = [];
 for (let i = 1; i <= 10; i++) {
   const frac = i / 20; // 5% .. 50%
+  const pct = Math.round(frac * 100);
   PROBES.push(makeBot({
     name: `Probe_${pad2(i)}`,
-    description: `Sends ${Math.round(frac * 100)}% of force toward the weakest neighbor.`,
+    description: `Sends ${pct}% of force toward the weakest neighbor.`,
     forceFrac: frac,
     forceMinPower: 1.0,
     minStrengthAbs: 2.0,
+    summary: `Probe family. Tiny commitments (${pct}% of strength - 1, floored at
+1.0) toward whichever neighbor scores lowest on enemy strength. The thesis
+is Swarm-like: spread thin, retain the home stack, and let the regrowth
+clock do the work. Probes are hard to kill because they always leave most
+of their strength behind, but they are also slow to take a heavy enemy
+tile — so they tend to win on map control rather than knockouts.`,
   }));
 }
 
+// ---------------------------------------------------------------- Patients
 const PATIENTS = [];
 for (let i = 1; i <= 10; i++) {
   const thresh = 0.1 + i * 0.08; // 18% .. 90%
+  const pct = Math.round(thresh * 100);
   PATIENTS.push(makeBot({
     name: `Patient_${pad2(i)}`,
-    description: `Holds until ${Math.round(thresh * 100)}% strength, then attacks weakest neighbor with balance.`,
+    description: `Holds until ${pct}% strength, then attacks weakest neighbor with balance.`,
     minStrengthFrac: thresh,
     forceMode: "balance",
+    summary: `Patient family. Sits idle until strength climbs to ${pct}% of
+maxStrength, then plays a balanceAttack on the weakest neighbor. The
+higher the threshold, the longer we hoard before moving — the better the
+single push, the more time we cede to neighbors who were already
+expanding. This bot is essentially Cautious with a tunable threshold; it
+trades early board presence for late-game punch.`,
   }));
 }
 
+// ---------------------------------------------------------------- Drifters
 const DRIFTS_SPEC = [
-  ["E",      [-2, 4, 0, 0]],
-  ["W",      [4, -2, 0, 0]],
-  ["N",      [0, 0, 4, -2]],
-  ["S",      [0, 0, -2, 4]],
-  ["NE",     [-2, 3, 3, -2]],
-  ["NW",     [3, -2, 3, -2]],
-  ["SE",     [-2, 3, -2, 3]],
-  ["SW",     [3, -2, -2, 3]],
-  ["EvN",    [-1, 1, 1, -1]],   // softer east+north pull
-  ["WvS",    [1, -1, -1, 1]],   // softer west+south pull
+  ["E",   [-2, 4, 0, 0],   "east"],
+  ["W",   [4, -2, 0, 0],   "west"],
+  ["N",   [0, 0, 4, -2],   "north"],
+  ["S",   [0, 0, -2, 4],   "south"],
+  ["NE",  [-2, 3, 3, -2],  "northeast"],
+  ["NW",  [3, -2, 3, -2],  "northwest"],
+  ["SE",  [-2, 3, -2, 3],  "southeast"],
+  ["SW",  [3, -2, -2, 3],  "southwest"],
+  ["EvN", [-1, 1, 1, -1],  "east-and-north (mild)"],
+  ["WvS", [1, -1, -1, 1],  "west-and-south (mild)"],
 ];
-const DRIFTS = DRIFTS_SPEC.map(([dir, grad]) => makeBot({
+const DRIFTS = DRIFTS_SPEC.map(([dir, grad, longName]) => makeBot({
   name: `Drift_${dir}`,
   description: `Like SlowAndSteady but biased ${dir}.`,
   gradient: grad,
   forceMode: "balance",
+  summary: `Drift family. Generalises Repel: every tick we score the four
+neighbors as SlowAndSteady would, then subtract a per-direction bonus
+[w,e,n,s] = [${grad.join(", ")}] before picking the lowest. The net effect
+is a constant lean toward ${longName}, regardless of where we started or
+who is in the way. Useful as a control: pairs of opposing drifts (E vs W,
+NE vs SW) test whether the map's geometry favours one direction. On
+non-wrapping maps this bot will eventually pin itself against a wall.`,
 }));
 
-const PACIFISTS = [];
-// Pacifists never engage enemies. They only land on empty tiles, with
-// varying minimum strengths and commitment fractions.
+// --------------------------------------------------------------- Pacifists
 const PACIFIST_SPEC = [
   { thresh: 0.0, frac: 0.5 },
   { thresh: 0.0, frac: 1.0 },
@@ -86,63 +123,84 @@ const PACIFIST_SPEC = [
   { thresh: 0.8, frac: 0.5 },
   { thresh: 0.8, frac: 1.0 },
 ];
-for (let i = 0; i < PACIFIST_SPEC.length; i++) {
-  const { thresh, frac } = PACIFIST_SPEC[i];
-  PACIFISTS.push(makeBot({
+const PACIFISTS = PACIFIST_SPEC.map(({ thresh, frac }, i) => {
+  const tpct = Math.round(thresh * 100);
+  const fpct = Math.round(frac * 100);
+  return makeBot({
     name: `Pacifist_${pad2(i + 1)}`,
-    description: `Expands only into empty tiles (>= ${Math.round(thresh * 100)}% strength, ${Math.round(frac * 100)}% commitment).`,
+    description: `Expands only into empty tiles (>= ${tpct}% strength, ${fpct}% commitment).`,
     requireEmpty: true,
     minStrengthFrac: thresh,
     forceFrac: frac,
-  }));
-}
+    summary: `Pacifist family. Refuses to attack any tile that is occupied —
+only spreads into empty squares. This bot acts only when at >= ${tpct}% of
+maxStrength and commits ${fpct}% of (strength - 1) per push. Pacifists
+race to enclose territory before the war starts; once enemies surround
+them they stop moving entirely and just regrow in place. Strong on open
+maps, brittle anywhere they can't outrun the front line. Predictable
+weakness: a Bully or Hunter on the border will eat them since they will
+never punch back.`,
+  });
+});
 
+// ---------------------------------------------------------------- Bullies
 const BULLIES = [];
 for (let i = 1; i <= 10; i++) {
   const frac = i / 10;
-  // Half the bullies require winnable, half charge regardless.
+  const pct = Math.round(frac * 100);
   const winnable = i % 2 === 0;
   BULLIES.push(makeBot({
     name: `Bully_${pad2(i)}`,
-    description: `Charges the STRONGEST adjacent enemy${winnable ? " it can beat" : ""}; ${Math.round(frac * 100)}% commitment.`,
+    description: `Charges the STRONGEST adjacent enemy${winnable ? " it can beat" : ""}; ${pct}% commitment.`,
     pickMode: "max",
     requireEnemy: true,
     requireWinnable: winnable,
     forceFrac: frac,
     fallbackName: "slow",
+    summary: `Bully family. Inverts Hunter: among neighbors with enemies, picks
+the STRONGEST stack${winnable ? " we can still beat with margin" : ", winnable or not"} and commits ${pct}% of
+(strength - 1). The thesis is that taking out the biggest threat swings
+matchups harder than nibbling away at peripheral stacks. ${winnable
+  ? "Half the family enforces winnability; this one does, so the bot will refuse hopeless trades."
+  : "This variant ignores winnability — it will charge into trades it loses, on the bet that mutual annihilation hurts the opponent more."} With no enemy
+adjacent, falls back to SlowAndSteady.`,
   }));
 }
 
-const CLUSTERS = [];
-// Reinforcers: prefer tiles with the most friendly armies. Vary how strongly
-// friendliness pulls and the activation strength threshold.
+// --------------------------------------------------------------- Clusters
 const CLUSTER_SPEC = [
-  { wf: 5,  thresh: 0.2 },
-  { wf: 5,  thresh: 0.5 },
-  { wf: 10, thresh: 0.2 },
-  { wf: 10, thresh: 0.5 },
-  { wf: 20, thresh: 0.3 },
-  { wf: 20, thresh: 0.7 },
-  { wf: 50, thresh: 0.4 },
-  { wf: 50, thresh: 0.85 },
-  { wf: 3,  thresh: 0.0 },
+  { wf: 5,   thresh: 0.2 },
+  { wf: 5,   thresh: 0.5 },
+  { wf: 10,  thresh: 0.2 },
+  { wf: 10,  thresh: 0.5 },
+  { wf: 20,  thresh: 0.3 },
+  { wf: 20,  thresh: 0.7 },
+  { wf: 50,  thresh: 0.4 },
+  { wf: 50,  thresh: 0.85 },
+  { wf: 3,   thresh: 0.0 },
   { wf: 100, thresh: 0.5 },
 ];
-for (let i = 0; i < CLUSTER_SPEC.length; i++) {
-  const { wf, thresh } = CLUSTER_SPEC[i];
-  CLUSTERS.push(makeBot({
+const CLUSTERS = CLUSTER_SPEC.map(({ wf, thresh }, i) => {
+  const tpct = Math.round(thresh * 100);
+  return makeBot({
     name: `Cluster_${pad2(i + 1)}`,
-    description: `Pulls toward tiles with friendly armies (weight ${wf}); waits until ${Math.round(thresh * 100)}% strength.`,
+    description: `Pulls toward tiles with friendly armies (weight ${wf}); waits until ${tpct}% strength.`,
     weightFriendly: wf,
     weightEnemy: 1,
     minStrengthFrac: thresh,
     forceMode: "balance",
-  }));
-}
+    summary: `Cluster family. Each tick, score = enemyStrength - ${wf} *
+friendlyCount. Waits to ${tpct}% strength then balanceAttacks the lowest
+score. With weight ${wf}, friendly density dominates enemy strength: the
+bot will gladly attack into a stronger enemy if doing so reinforces a
+neighboring friendly stack. The intended behaviour is Defender-like
+column formation — armies pile onto each other and march as a brick.
+Overcommits in early game when there are no friendlies adjacent yet, so
+the threshold gates the wandering until reinforcements exist.`,
+  });
+});
 
-const SCATTERS = [];
-// Anti-cluster: never land on a tile that already has a friendly. Vary
-// commitment and whether they prefer empty over enemy.
+// ---------------------------------------------------------------- Scatter
 const SCATTER_SPEC = [
   { frac: 0.5, emptyBonus: 0 },
   { frac: 1.0, emptyBonus: 0 },
@@ -155,47 +213,54 @@ const SCATTER_SPEC = [
   { frac: 0.9, emptyBonus: 50 },
   { frac: 0.4, emptyBonus: 0 },
 ];
-for (let i = 0; i < SCATTER_SPEC.length; i++) {
-  const { frac, emptyBonus } = SCATTER_SPEC[i];
-  SCATTERS.push(makeBot({
+const SCATTERS = SCATTER_SPEC.map(({ frac, emptyBonus }, i) => {
+  const fpct = Math.round(frac * 100);
+  return makeBot({
     name: `Scatter_${pad2(i + 1)}`,
-    description: `Avoids friendly tiles${emptyBonus ? ", prefers empty ones" : ""}; ${Math.round(frac * 100)}% commitment.`,
+    description: `Avoids friendly tiles${emptyBonus ? ", prefers empty ones" : ""}; ${fpct}% commitment.`,
     avoidFriendly: true,
     weightEmptyBonus: emptyBonus,
     forceFrac: frac,
-  }));
-}
+    summary: `Scatter family. Inverse of Cluster: filters out any neighbor
+already held by a friendly, so we never stack. ${emptyBonus
+  ? `Empty tiles get a +${emptyBonus} bonus, biasing expansion outward instead of into enemy stacks.`
+  : "No empty bonus, so target choice depends purely on enemy strength."} Commits ${fpct}% of (strength - 1) per push. Thesis: spreading guarantees
+maximum tile coverage while leaving the home stack intact, but it also
+means we are always fighting alone — no reinforcements arrive because we
+specifically refuse to send any. Strong against Cluster, weak against
+Bully, since concentrated force beats distributed force one-on-one.`,
+  });
+});
 
-const PULSES = [];
-// Tick-gated bots: act only on selected ticks. The "off" ticks let strength
-// regenerate. Vary period, phase, and commitment mode.
+// ----------------------------------------------------------------- Pulses
 const PULSE_SPEC = [
-  { period: 2, phase: 0, mode: "all",     desc: "every other tick (even), all-in" },
-  { period: 2, phase: 1, mode: "all",     desc: "every other tick (odd), all-in" },
-  { period: 3, phase: 0, mode: "all",     desc: "every 3rd tick, all-in" },
-  { period: 3, phase: 0, mode: "balance", desc: "every 3rd tick, balanced" },
-  { period: 4, phase: 0, mode: "all",     desc: "every 4th tick, all-in" },
-  { period: 4, phase: 2, mode: "balance", desc: "every 4th tick (offset), balanced" },
-  { period: 5, phase: 0, mode: "all",     desc: "every 5th tick, all-in" },
-  { period: 6, phase: 0, mode: "balance", desc: "every 6th tick, balanced" },
-  { period: 8, phase: 0, mode: "all",     desc: "every 8th tick, all-in" },
-  { period: 10, phase: 0, mode: "all",    desc: "every 10th tick, all-in" },
+  { period: 2,  phase: 0, mode: "all",     desc: "every other tick (even), all-in" },
+  { period: 2,  phase: 1, mode: "all",     desc: "every other tick (odd), all-in" },
+  { period: 3,  phase: 0, mode: "all",     desc: "every 3rd tick, all-in" },
+  { period: 3,  phase: 0, mode: "balance", desc: "every 3rd tick, balanced" },
+  { period: 4,  phase: 0, mode: "all",     desc: "every 4th tick, all-in" },
+  { period: 4,  phase: 2, mode: "balance", desc: "every 4th tick (offset), balanced" },
+  { period: 5,  phase: 0, mode: "all",     desc: "every 5th tick, all-in" },
+  { period: 6,  phase: 0, mode: "balance", desc: "every 6th tick, balanced" },
+  { period: 8,  phase: 0, mode: "all",     desc: "every 8th tick, all-in" },
+  { period: 10, phase: 0, mode: "all",     desc: "every 10th tick, all-in" },
 ];
-for (let i = 0; i < PULSE_SPEC.length; i++) {
-  const s = PULSE_SPEC[i];
-  PULSES.push(makeBot({
-    name: `Pulse_${pad2(i + 1)}`,
-    description: `Acts ${s.desc}; targets weakest neighbor on active ticks.`,
-    tickPeriod: s.period,
-    tickPhase: s.phase,
-    forceMode: s.mode,
-    forceFrac: 1.0,
-  }));
-}
+const PULSES = PULSE_SPEC.map((s, i) => makeBot({
+  name: `Pulse_${pad2(i + 1)}`,
+  description: `Acts ${s.desc}; targets weakest neighbor on active ticks.`,
+  tickPeriod: s.period,
+  tickPhase: s.phase,
+  forceMode: s.mode,
+  forceFrac: 1.0,
+  summary: `Pulse family. Acts only on ticks where (game.tick % ${s.period}) ===
+${s.phase}; otherwise sits silent and lets growth top up strength. On
+active ticks, ${s.mode === "all" ? "commits all available strength (s - 1)" : "plays balanceAttack against the weakest neighbor"}. The longer the period,
+the bigger each pulse but the longer the gap during which an opponent
+could swarm us. Out-of-phase Pulses (e.g. _01 vs _02) are useful as
+matched-cadence controls: same logic, opposite tick parity.`,
+}));
 
-// Stencil bots: build kernels keyed to direction (0=W,1=E,2=N,3=S).
-// Each pattern is an array of [dr, dc, weight] entries; we splat it into a
-// 5x5 kernel rotated for each direction. Centre is (2,2).
+// --------------------------------------------------------------- Stencils
 function kernelFromOffsets(offsets) {
   const k = Array.from({ length: 5 }, () => [0, 0, 0, 0, 0]);
   for (const [dr, dc, w] of offsets) k[2 + dr][2 + dc] = w;
@@ -204,10 +269,6 @@ function kernelFromOffsets(offsets) {
 
 function rotateOffsetsForDir(offsets, dir) {
   // Base offsets are written for direction = East. Rotate for others.
-  // East: (dr, dc) unchanged
-  // West: (dr, -dc)
-  // North: (-dc, dr)
-  // South: (dc, -dr)
   return offsets.map(([dr, dc, w]) => {
     switch (dir) {
       case 0: return [dr, -dc, w];   // West
@@ -225,39 +286,37 @@ function fourKernels(eastPattern) {
   );
 }
 
-// Each "pattern" is a friendly-density preference for the East direction.
-// Positive cells = "I want my friendlies HERE before I push east."
 const STENCIL_PATTERNS = [
-  // Forward line (push toward an east-pointing friendly stripe)
-  { name: "01", desc: "front-line: friendlies one step east",
-    east: [[0, 1, 1], [0, 2, 1]] },
-  // Backstop: friendlies behind, push forward
-  { name: "02", desc: "backstop: friendlies west, push east",
-    east: [[0, -1, 1], [0, -2, 1]] },
-  // Wedge: friendlies on diagonals
+  { name: "01", desc: "front-line: friendlies one step ahead",
+    east: [[0, 1, 1], [0, 2, 1]],
+    thesis: "Push toward a friendly stripe directly ahead. Forms columnar advances behind a forward picket of allies." },
+  { name: "02", desc: "backstop: friendlies behind, push forward",
+    east: [[0, -1, 1], [0, -2, 1]],
+    thesis: "Move AWAY from clumps of friendlies, treating them as a backstop. Encourages frontier expansion while keeping backfield dense." },
   { name: "03", desc: "wedge: friendlies on forward diagonals",
-    east: [[1, 1, 1], [-1, 1, 1]] },
-  // Flank-protected: friendlies on flanks
+    east: [[1, 1, 1], [-1, 1, 1]],
+    thesis: "Form a wedge: prefer directions where friendlies are diagonally ahead. Naturally produces V-shaped formations on open ground." },
   { name: "04", desc: "flank-protected: friendlies on perpendicular flanks",
-    east: [[1, 0, 1], [-1, 0, 1]] },
-  // Original Trinity-style three-in-a-row
-  { name: "05", desc: "trinity: friendly + diagonal + center",
-    east: [[-1, 1, 1], [0, 1, 1], [1, 1, 1]] },
-  // Distant push: only far cells matter
+    east: [[1, 0, 1], [-1, 0, 1]],
+    thesis: "Move in the direction perpendicular to where our flanks already exist. Encourages line formations rather than columns." },
+  { name: "05", desc: "trinity: classic three-in-a-row",
+    east: [[-1, 1, 1], [0, 1, 1], [1, 1, 1]],
+    thesis: "A direct port of Trinity's kernel-style heuristic: prefer directions where three friendlies form a row ahead. Tested baseline." },
   { name: "06", desc: "long-range: pulls toward friendlies two tiles ahead",
-    east: [[0, 2, 2], [-1, 2, 1], [1, 2, 1]] },
-  // Repel: AVOID friendlies ahead (negative weight) -> spread out
+    east: [[0, 2, 2], [-1, 2, 1], [1, 2, 1]],
+    thesis: "Look further ahead than Trinity. Larger-radius friendly detection helps merge separate detachments at range." },
   { name: "07", desc: "repel: avoids friendlies ahead, seeks open ground",
-    east: [[0, 1, -2], [0, 2, -1]] },
-  // L-shape preference
+    east: [[0, 1, -2], [0, 2, -1]],
+    thesis: "Negative weights ahead — actively repelled by friendly density in the chosen direction. Net result is reliable scattering, like Repel without a fixed compass bias." },
   { name: "08", desc: "L-shape: friendly ahead and to one side",
-    east: [[0, 1, 1], [1, 1, 1], [1, 0, 1]] },
-  // Box: surround pattern
+    east: [[0, 1, 1], [1, 1, 1], [1, 0, 1]],
+    thesis: "Prefer L-shaped friendly groupings. Tends to round corners and curl around obstacles." },
   { name: "09", desc: "box: friendlies forming a forward ring",
-    east: [[1, 1, 1], [-1, 1, 1], [0, 2, 1], [1, 2, 1], [-1, 2, 1]] },
-  // Asymmetric: two ahead one behind
+    east: [[1, 1, 1], [-1, 1, 1], [0, 2, 1], [1, 2, 1], [-1, 2, 1]],
+    thesis: "Score directions that already have a partial ring of friendlies ahead — pushes us into pockets we mostly already control, building hard borders." },
   { name: "10", desc: "asymmetric: forward bias with rear support",
-    east: [[0, 1, 2], [0, 2, 1], [0, -1, 1]] },
+    east: [[0, 1, 2], [0, 2, 1], [0, -1, 1]],
+    thesis: "Front-loaded weights with a small rear-support term. Compromise between Stencil_01 (pure forward) and Stencil_02 (pure backstop)." },
 ];
 const STENCILS = STENCIL_PATTERNS.map((p) => makeStencilBot({
   name: `Stencil_${p.name}`,
@@ -265,8 +324,16 @@ const STENCILS = STENCIL_PATTERNS.map((p) => makeStencilBot({
   kernels: fourKernels(p.east),
   forceMode: "all",
   fallbackName: "slow",
+  summary: `Stencil family. Builds four 5x5 kernels (one per cardinal
+direction) by writing a single offset pattern aimed east and rotating it
+for the other three. Each tick we convolve the kernels against the tile's
+stencil5 view of friendly density, pick the direction with the highest
+score, and commit (strength - 1).
+${p.thesis}
+Falls back to SlowAndSteady when no direction is viable.`,
 }));
 
+// ------------------------------------------------------------------ All
 export const GENERATED = [
   ...HUNTERS,
   ...PROBES,

--- a/src/strategies/generated.js
+++ b/src/strategies/generated.js
@@ -1,0 +1,281 @@
+// 100 parameterized bots, built from src/strategies/factory.js. Grouped into
+// ten thematic families of ten:
+//
+//   Hunter_*      target weakest WINNABLE enemy; vary commitment fraction
+//   Probe_*       send a small fractional force toward the weakest neighbor
+//   Patient_*     wait until a strength threshold, then attack
+//   Drift_*       bias movement in a specific compass direction
+//   Pacifist_*    only attack empty tiles; vary expansion appetite
+//   Bully_*       target the STRONGEST enemy (whether winnable or not)
+//   Cluster_*     prefer attacking tiles already held by friendlies
+//   Scatter_*     refuse to land on friendly tiles; vary target preference
+//   Pulse_*       only act on a tick cadence (period & phase)
+//   Stencil_*     pick direction by convolving 5x5 kernels (Trinity-style)
+
+import { makeBot, makeStencilBot } from "./factory.js";
+
+const pad2 = (n) => String(n).padStart(2, "0");
+
+const HUNTERS = [];
+for (let i = 1; i <= 10; i++) {
+  const frac = i / 10;
+  HUNTERS.push(makeBot({
+    name: `Hunter_${pad2(i)}`,
+    description: `Targets weakest beatable enemy; commits ${Math.round(frac * 100)}% of force.`,
+    requireEnemy: true,
+    requireWinnable: true,
+    forceFrac: frac,
+    fallbackName: "slow",
+  }));
+}
+
+const PROBES = [];
+for (let i = 1; i <= 10; i++) {
+  const frac = i / 20; // 5% .. 50%
+  PROBES.push(makeBot({
+    name: `Probe_${pad2(i)}`,
+    description: `Sends ${Math.round(frac * 100)}% of force toward the weakest neighbor.`,
+    forceFrac: frac,
+    forceMinPower: 1.0,
+    minStrengthAbs: 2.0,
+  }));
+}
+
+const PATIENTS = [];
+for (let i = 1; i <= 10; i++) {
+  const thresh = 0.1 + i * 0.08; // 18% .. 90%
+  PATIENTS.push(makeBot({
+    name: `Patient_${pad2(i)}`,
+    description: `Holds until ${Math.round(thresh * 100)}% strength, then attacks weakest neighbor with balance.`,
+    minStrengthFrac: thresh,
+    forceMode: "balance",
+  }));
+}
+
+const DRIFTS_SPEC = [
+  ["E",      [-2, 4, 0, 0]],
+  ["W",      [4, -2, 0, 0]],
+  ["N",      [0, 0, 4, -2]],
+  ["S",      [0, 0, -2, 4]],
+  ["NE",     [-2, 3, 3, -2]],
+  ["NW",     [3, -2, 3, -2]],
+  ["SE",     [-2, 3, -2, 3]],
+  ["SW",     [3, -2, -2, 3]],
+  ["EvN",    [-1, 1, 1, -1]],   // softer east+north pull
+  ["WvS",    [1, -1, -1, 1]],   // softer west+south pull
+];
+const DRIFTS = DRIFTS_SPEC.map(([dir, grad]) => makeBot({
+  name: `Drift_${dir}`,
+  description: `Like SlowAndSteady but biased ${dir}.`,
+  gradient: grad,
+  forceMode: "balance",
+}));
+
+const PACIFISTS = [];
+// Pacifists never engage enemies. They only land on empty tiles, with
+// varying minimum strengths and commitment fractions.
+const PACIFIST_SPEC = [
+  { thresh: 0.0, frac: 0.5 },
+  { thresh: 0.0, frac: 1.0 },
+  { thresh: 0.2, frac: 0.5 },
+  { thresh: 0.2, frac: 1.0 },
+  { thresh: 0.4, frac: 0.5 },
+  { thresh: 0.4, frac: 1.0 },
+  { thresh: 0.6, frac: 0.5 },
+  { thresh: 0.6, frac: 1.0 },
+  { thresh: 0.8, frac: 0.5 },
+  { thresh: 0.8, frac: 1.0 },
+];
+for (let i = 0; i < PACIFIST_SPEC.length; i++) {
+  const { thresh, frac } = PACIFIST_SPEC[i];
+  PACIFISTS.push(makeBot({
+    name: `Pacifist_${pad2(i + 1)}`,
+    description: `Expands only into empty tiles (>= ${Math.round(thresh * 100)}% strength, ${Math.round(frac * 100)}% commitment).`,
+    requireEmpty: true,
+    minStrengthFrac: thresh,
+    forceFrac: frac,
+  }));
+}
+
+const BULLIES = [];
+for (let i = 1; i <= 10; i++) {
+  const frac = i / 10;
+  // Half the bullies require winnable, half charge regardless.
+  const winnable = i % 2 === 0;
+  BULLIES.push(makeBot({
+    name: `Bully_${pad2(i)}`,
+    description: `Charges the STRONGEST adjacent enemy${winnable ? " it can beat" : ""}; ${Math.round(frac * 100)}% commitment.`,
+    pickMode: "max",
+    requireEnemy: true,
+    requireWinnable: winnable,
+    forceFrac: frac,
+    fallbackName: "slow",
+  }));
+}
+
+const CLUSTERS = [];
+// Reinforcers: prefer tiles with the most friendly armies. Vary how strongly
+// friendliness pulls and the activation strength threshold.
+const CLUSTER_SPEC = [
+  { wf: 5,  thresh: 0.2 },
+  { wf: 5,  thresh: 0.5 },
+  { wf: 10, thresh: 0.2 },
+  { wf: 10, thresh: 0.5 },
+  { wf: 20, thresh: 0.3 },
+  { wf: 20, thresh: 0.7 },
+  { wf: 50, thresh: 0.4 },
+  { wf: 50, thresh: 0.85 },
+  { wf: 3,  thresh: 0.0 },
+  { wf: 100, thresh: 0.5 },
+];
+for (let i = 0; i < CLUSTER_SPEC.length; i++) {
+  const { wf, thresh } = CLUSTER_SPEC[i];
+  CLUSTERS.push(makeBot({
+    name: `Cluster_${pad2(i + 1)}`,
+    description: `Pulls toward tiles with friendly armies (weight ${wf}); waits until ${Math.round(thresh * 100)}% strength.`,
+    weightFriendly: wf,
+    weightEnemy: 1,
+    minStrengthFrac: thresh,
+    forceMode: "balance",
+  }));
+}
+
+const SCATTERS = [];
+// Anti-cluster: never land on a tile that already has a friendly. Vary
+// commitment and whether they prefer empty over enemy.
+const SCATTER_SPEC = [
+  { frac: 0.5, emptyBonus: 0 },
+  { frac: 1.0, emptyBonus: 0 },
+  { frac: 0.5, emptyBonus: 5 },
+  { frac: 1.0, emptyBonus: 5 },
+  { frac: 0.5, emptyBonus: 20 },
+  { frac: 1.0, emptyBonus: 20 },
+  { frac: 0.3, emptyBonus: 10 },
+  { frac: 0.7, emptyBonus: 10 },
+  { frac: 0.9, emptyBonus: 50 },
+  { frac: 0.4, emptyBonus: 0 },
+];
+for (let i = 0; i < SCATTER_SPEC.length; i++) {
+  const { frac, emptyBonus } = SCATTER_SPEC[i];
+  SCATTERS.push(makeBot({
+    name: `Scatter_${pad2(i + 1)}`,
+    description: `Avoids friendly tiles${emptyBonus ? ", prefers empty ones" : ""}; ${Math.round(frac * 100)}% commitment.`,
+    avoidFriendly: true,
+    weightEmptyBonus: emptyBonus,
+    forceFrac: frac,
+  }));
+}
+
+const PULSES = [];
+// Tick-gated bots: act only on selected ticks. The "off" ticks let strength
+// regenerate. Vary period, phase, and commitment mode.
+const PULSE_SPEC = [
+  { period: 2, phase: 0, mode: "all",     desc: "every other tick (even), all-in" },
+  { period: 2, phase: 1, mode: "all",     desc: "every other tick (odd), all-in" },
+  { period: 3, phase: 0, mode: "all",     desc: "every 3rd tick, all-in" },
+  { period: 3, phase: 0, mode: "balance", desc: "every 3rd tick, balanced" },
+  { period: 4, phase: 0, mode: "all",     desc: "every 4th tick, all-in" },
+  { period: 4, phase: 2, mode: "balance", desc: "every 4th tick (offset), balanced" },
+  { period: 5, phase: 0, mode: "all",     desc: "every 5th tick, all-in" },
+  { period: 6, phase: 0, mode: "balance", desc: "every 6th tick, balanced" },
+  { period: 8, phase: 0, mode: "all",     desc: "every 8th tick, all-in" },
+  { period: 10, phase: 0, mode: "all",    desc: "every 10th tick, all-in" },
+];
+for (let i = 0; i < PULSE_SPEC.length; i++) {
+  const s = PULSE_SPEC[i];
+  PULSES.push(makeBot({
+    name: `Pulse_${pad2(i + 1)}`,
+    description: `Acts ${s.desc}; targets weakest neighbor on active ticks.`,
+    tickPeriod: s.period,
+    tickPhase: s.phase,
+    forceMode: s.mode,
+    forceFrac: 1.0,
+  }));
+}
+
+// Stencil bots: build kernels keyed to direction (0=W,1=E,2=N,3=S).
+// Each pattern is an array of [dr, dc, weight] entries; we splat it into a
+// 5x5 kernel rotated for each direction. Centre is (2,2).
+function kernelFromOffsets(offsets) {
+  const k = Array.from({ length: 5 }, () => [0, 0, 0, 0, 0]);
+  for (const [dr, dc, w] of offsets) k[2 + dr][2 + dc] = w;
+  return k;
+}
+
+function rotateOffsetsForDir(offsets, dir) {
+  // Base offsets are written for direction = East. Rotate for others.
+  // East: (dr, dc) unchanged
+  // West: (dr, -dc)
+  // North: (-dc, dr)
+  // South: (dc, -dr)
+  return offsets.map(([dr, dc, w]) => {
+    switch (dir) {
+      case 0: return [dr, -dc, w];   // West
+      case 1: return [dr, dc, w];    // East
+      case 2: return [-dc, dr, w];   // North
+      case 3: return [dc, -dr, w];   // South
+    }
+    return [dr, dc, w];
+  });
+}
+
+function fourKernels(eastPattern) {
+  return [0, 1, 2, 3].map((dir) =>
+    kernelFromOffsets(rotateOffsetsForDir(eastPattern, dir))
+  );
+}
+
+// Each "pattern" is a friendly-density preference for the East direction.
+// Positive cells = "I want my friendlies HERE before I push east."
+const STENCIL_PATTERNS = [
+  // Forward line (push toward an east-pointing friendly stripe)
+  { name: "01", desc: "front-line: friendlies one step east",
+    east: [[0, 1, 1], [0, 2, 1]] },
+  // Backstop: friendlies behind, push forward
+  { name: "02", desc: "backstop: friendlies west, push east",
+    east: [[0, -1, 1], [0, -2, 1]] },
+  // Wedge: friendlies on diagonals
+  { name: "03", desc: "wedge: friendlies on forward diagonals",
+    east: [[1, 1, 1], [-1, 1, 1]] },
+  // Flank-protected: friendlies on flanks
+  { name: "04", desc: "flank-protected: friendlies on perpendicular flanks",
+    east: [[1, 0, 1], [-1, 0, 1]] },
+  // Original Trinity-style three-in-a-row
+  { name: "05", desc: "trinity: friendly + diagonal + center",
+    east: [[-1, 1, 1], [0, 1, 1], [1, 1, 1]] },
+  // Distant push: only far cells matter
+  { name: "06", desc: "long-range: pulls toward friendlies two tiles ahead",
+    east: [[0, 2, 2], [-1, 2, 1], [1, 2, 1]] },
+  // Repel: AVOID friendlies ahead (negative weight) -> spread out
+  { name: "07", desc: "repel: avoids friendlies ahead, seeks open ground",
+    east: [[0, 1, -2], [0, 2, -1]] },
+  // L-shape preference
+  { name: "08", desc: "L-shape: friendly ahead and to one side",
+    east: [[0, 1, 1], [1, 1, 1], [1, 0, 1]] },
+  // Box: surround pattern
+  { name: "09", desc: "box: friendlies forming a forward ring",
+    east: [[1, 1, 1], [-1, 1, 1], [0, 2, 1], [1, 2, 1], [-1, 2, 1]] },
+  // Asymmetric: two ahead one behind
+  { name: "10", desc: "asymmetric: forward bias with rear support",
+    east: [[0, 1, 2], [0, 2, 1], [0, -1, 1]] },
+];
+const STENCILS = STENCIL_PATTERNS.map((p) => makeStencilBot({
+  name: `Stencil_${p.name}`,
+  description: `Convolves a 5x5 kernel (${p.desc}) and pushes that way.`,
+  kernels: fourKernels(p.east),
+  forceMode: "all",
+  fallbackName: "slow",
+}));
+
+export const GENERATED = [
+  ...HUNTERS,
+  ...PROBES,
+  ...PATIENTS,
+  ...DRIFTS,
+  ...PACIFISTS,
+  ...BULLIES,
+  ...CLUSTERS,
+  ...SCATTERS,
+  ...PULSES,
+  ...STENCILS,
+];

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -7,6 +7,7 @@ import Random from "./Random.js";
 import Berserker from "./Berserker.js";
 import Cautious from "./Cautious.js";
 import Swarm from "./Swarm.js";
+import { GENERATED } from "./generated.js";
 
 export const STRATEGY_LIST = [
   SlowAndSteady,
@@ -18,6 +19,7 @@ export const STRATEGY_LIST = [
   Berserker,
   Cautious,
   Swarm,
+  ...GENERATED,
 ];
 
 export const STRATEGIES = Object.fromEntries(STRATEGY_LIST.map((s) => [s.name, s]));


### PR DESCRIPTION
## Summary
Introduces a factory-based system for generating parameterized bot strategies, creating 100 distinct named bots organized into 10 thematic families. This replaces manual strategy coding with a configuration-driven approach.

## Key Changes

- **New `src/strategies/factory.js`**: Implements two factory functions:
  - `makeBot()`: Creates strategies by scanning four neighbors, scoring them with configurable weights and filters, then selecting and attacking based on parameters
  - `makeStencilBot()`: Creates strategies using 5x5 kernel convolution (Trinity-style) to pick directions based on friendly density patterns

- **New `src/strategies/generated.js`**: Generates 100 parameterized bots in 10 families:
  - **Hunters** (10): Target weakest beatable enemy; vary commitment fraction (10%-100%)
  - **Probes** (10): Send small fractional force toward weakest neighbor (5%-50%)
  - **Patients** (10): Wait until strength threshold, then attack (18%-90%)
  - **Drifts** (10): Bias movement in compass directions (8 cardinal + 2 mild diagonals)
  - **Pacifists** (10): Only attack empty tiles; vary expansion appetite
  - **Bullies** (10): Target strongest enemy; alternate between winnable/reckless variants
  - **Clusters** (10): Prefer attacking tiles with friendly armies nearby
  - **Scatters** (10): Avoid friendly tiles; vary empty tile preference
  - **Pulses** (10): Act on tick cadence (periods 2-10); vary commitment mode
  - **Stencils** (10): Use 5x5 kernel patterns (front-line, backstop, wedge, flank, trinity, etc.)

- **Updated `src/strategies/index.js`**: Imports and exports the 100 generated strategies alongside existing hand-coded ones

## Implementation Details

- Each bot carries a `summary` field describing its family thesis with specific parameters spliced in
- Configuration parameters include: activation gates (min strength, tick gating), scoring weights (enemy/friendly/gradient), eligibility filters (winnable/enemy/empty/friendly), selection mode (min/max), and commitment modes (fractional/all/balance/absolute)
- Stencil kernels are defined as offset patterns for the east direction and rotated programmatically for other cardinal directions
- Fallback behaviors (slow, balance, berserk, wait) handle cases where no neighbor passes filters
- All generated bots use `author: "factory"` and `version: 1` for tracking

https://claude.ai/code/session_018FpTzq6FXGZdS13nS6xowm