### PR TITLE
Add strategy tooltip on player row hover

### DIFF
--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -75,9 +75,9 @@ export class HUD {
       head.innerHTML = `
         <span class="player-dot" style="background:${player.color}"></span>
         <span class="player-name">${escapeHtml(player.name)}</span>
-        <span class="player-stat">⚔ <b data-stat="armies">0</b></span>
-        <span class="player-stat">⬢ <b data-stat="strength">0</b></span>
-        <span class="player-stat">▣ <b data-stat="territory">0</b></span>
+        <span class="player-stat" title="Armies">⚔ <b data-stat="armies">0</b></span>
+        <span class="player-stat" title="Strength">⬢ <b data-stat="strength">0</b></span>
+        <span class="player-stat" title="Territory">▣ <b data-stat="territory">0</b></span>
       `;
 
       const select = document.createElement("select");

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -75,7 +75,6 @@ export class HUD {
       head.innerHTML = `
         <span class="player-dot" style="background:${player.color}"></span>
         <span class="player-name">${escapeHtml(player.name)}</span>
-        <span class="player-stat" title="Armies">⚔ <b data-stat="armies">0</b></span>
         <span class="player-stat" title="Strength">⬢ <b data-stat="strength">0</b></span>
         <span class="player-stat" title="Territory">▣ <b data-stat="territory">0</b></span>
       `;
@@ -134,7 +133,6 @@ export class HUD {
     for (const player of this.game.players.list) {
       const row = this.root.querySelector(`[data-player-id="${player.id}"]`);
       if (!row) continue;
-      row.querySelector('[data-stat="armies"]').textContent = player.totals.armies;
       row.querySelector('[data-stat="strength"]').textContent = player.totals.strength.toFixed(1);
       row.querySelector('[data-stat="territory"]').textContent = player.totals.territory;
       const fill = row.querySelector(".strength-fill");

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -6,6 +6,10 @@ export class HUD {
     this.root = root;
     this.game = game;
     this.app = app;
+    this.tooltip = document.createElement("div");
+    this.tooltip.className = "strat-tooltip";
+    this.tooltip.style.display = "none";
+    document.body.appendChild(this.tooltip);
     this.render();
     game.on("players:changed", () => this.render());
   }
@@ -16,7 +20,45 @@ export class HUD {
     this.render();
   }
 
+  showTooltip(player, row) {
+    const strat = player.strategy;
+    if (!strat) return;
+    const title = strat.name ?? "";
+    const body = strat.summary || strat.description || "";
+    if (!body) return;
+    this.tooltip.innerHTML = `
+      <div class="strat-tooltip-title">${escapeHtml(title)}</div>
+      <div class="strat-tooltip-body">${escapeHtml(body)}</div>
+    `;
+    this.tooltip.style.setProperty("--player-color", player.color);
+    this.tooltip.style.display = "block";
+    this.positionTooltip(row);
+  }
+
+  positionTooltip(row) {
+    const rect = row.getBoundingClientRect();
+    const tt = this.tooltip;
+    tt.style.left = "0px";
+    tt.style.top = "0px";
+    const ttRect = tt.getBoundingClientRect();
+    const margin = 10;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    let left = rect.left - ttRect.width - margin;
+    if (left < margin) left = rect.right + margin;
+    if (left + ttRect.width > vw - margin) left = Math.max(margin, vw - ttRect.width - margin);
+    let top = rect.top;
+    if (top + ttRect.height > vh - margin) top = Math.max(margin, vh - ttRect.height - margin);
+    tt.style.left = `${left}px`;
+    tt.style.top = `${top}px`;
+  }
+
+  hideTooltip() {
+    this.tooltip.style.display = "none";
+  }
+
   render() {
+    this.hideTooltip();
     this.root.innerHTML = "";
     if (!this.game.players.list.length) {
       this.root.innerHTML = `<div class="hud-empty">No players. Add one in Sandbox.</div>`;
@@ -53,6 +95,7 @@ export class HUD {
       select.addEventListener("change", () => {
         player.strategy = STRATEGIES[select.value];
         select.title = player.strategy?.description ?? "";
+        if (this.tooltip.style.display === "block") this.showTooltip(player, row);
       });
 
       const bar = document.createElement("div");
@@ -75,6 +118,9 @@ export class HUD {
         });
         row.appendChild(select2);
       }
+
+      row.addEventListener("mouseenter", () => this.showTooltip(player, row));
+      row.addEventListener("mouseleave", () => this.hideTooltip());
 
       row.dataset.playerId = player.id;
       this.root.appendChild(row);

--- a/styles.css
+++ b/styles.css
@@ -265,6 +265,37 @@ select.dropdown {
   gap: 6px;
 }
 
+.strat-tooltip {
+  position: fixed;
+  width: 300px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--bg-1);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--player-color, var(--accent));
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+  line-height: 1.5;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.strat-tooltip-title {
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--player-color, var(--accent));
+  margin-bottom: 6px;
+  letter-spacing: 0.3px;
+}
+
+.strat-tooltip-body {
+  color: var(--text-dim);
+  white-space: pre-wrap;
+}
+
 .player-head {
   display: flex;
   align-items: center;

--- a/styles.css
+++ b/styles.css
@@ -299,8 +299,8 @@ select.dropdown {
 .player-head {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: 10px;
+  font-size: 14px;
 }
 
 .player-dot {
@@ -317,7 +317,7 @@ select.dropdown {
 
 .player-stat {
   font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 11px;
+  font-size: 13px;
   color: var(--text-dim);
 }
 


### PR DESCRIPTION
## Summary
Added an interactive tooltip system that displays strategy information when hovering over player rows in the HUD. The tooltip shows the strategy name and description/summary with smart positioning to keep it visible within the viewport.

## Key Changes
- **Tooltip Creation & Management**: Added tooltip element initialization in HUD constructor with methods to show, hide, and position the tooltip
- **Hover Interactions**: Attached mouseenter/mouseleave event listeners to player rows to trigger tooltip display
- **Smart Positioning**: Implemented `positionTooltip()` method that intelligently places the tooltip to the left of the row, falling back to the right if there's insufficient space, and adjusts vertical position to stay within viewport bounds
- **Dynamic Content**: Tooltip displays player's strategy name and summary/description with proper HTML escaping
- **Visual Styling**: Added comprehensive CSS styling for `.strat-tooltip` with player color accent border, shadow effects, and responsive sizing
- **Strategy Change Handling**: Tooltip updates when strategy selection changes if it's currently visible
- **UI Refinements**: 
  - Removed "armies" stat display from player rows
  - Added title attributes to remaining stats (Strength, Territory)
  - Adjusted font sizes and spacing in player header for better readability

## Implementation Details
- Tooltip uses CSS custom property `--player-color` to dynamically color the left border and title based on the player's color
- Positioning accounts for 10px margins and uses `getBoundingClientRect()` for accurate viewport calculations
- Tooltip has `pointer-events: none` to prevent interfering with underlying interactions
- Content is sanitized using `escapeHtml()` to prevent XSS vulnerabilities

https://claude.ai/code/session_01JYUMfM4eiTcrDfuKoRw6VN