### PR TITLE
Add four new strategy bots: Crusader, Conqueror, Stalker, Citadel

### DIFF
--- a/src/strategies/Citadel.js
+++ b/src/strategies/Citadel.js
@@ -1,0 +1,66 @@
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+
+// Mode-switcher built on top of Conqueror. Conqueror already does the
+// right thing when we're at least at parity locally: minimum-overkill
+// kills, friendly balance, take-empties. The thing it doesn't handle
+// is when we're outnumbered — a full-strength enemy stack adjacent that
+// we can't beat solo. In that situation we want to consolidate, not
+// commit. Citadel adds exactly that gate.
+export default {
+  name: "Citadel",
+  author: "claude",
+  version: 1,
+  description: "Conqueror that consolidates onto the strongest friendly when outnumbered.",
+  summary: `Adaptive's switcher idea was right but its sub-bots all under-use
+the engine's 1.4x bonus. Citadel is much simpler: by default play
+Conqueror (which already handles kills, empties, and balanced
+reinforcement). Override only when we are clearly outnumbered locally
+(adjacent enemy mass > strength * 1.4 — the threshold beyond which an
+attacker bonus can't save us): in that case bleed surplus into the
+fattest friendly neighbor instead, building a stack that *can* fight.
+The hypothesis is that Adaptive lost rank because Defender's hoard
+mode hoards forever; Citadel only triggers consolidation while the
+threat is live, then snaps back to Conqueror the next tick once the
+neighborhood arithmetic shifts.`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    let enemyAdj = 0;
+    let fattestFriendly = null;
+    let fattestStrength = -1;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) {
+          if (a.strength > fattestStrength) {
+            fattestStrength = a.strength;
+            fattestFriendly = t;
+          }
+        } else {
+          enemyAdj += a.strength;
+        }
+      }
+    }
+
+    // Outnumbered AND have a friendly to fall back on: stack up.
+    if (enemyAdj > army.strength * BONUS && fattestFriendly && army.strength > 3) {
+      const room = (fattestStrength >= 0 ? army.maxStrength - fattestStrength : army.maxStrength);
+      if (room > 0.6) {
+        const power = Math.min(army.strength - 1, room);
+        if (power > 0.5) {
+          army.attack(fattestFriendly, power);
+          return;
+        }
+      }
+    }
+
+    Conqueror.act(army, game);
+  },
+};

--- a/src/strategies/Conqueror.js
+++ b/src/strategies/Conqueror.js
@@ -1,0 +1,132 @@
+import { sumStrength, totalStrength } from "../core/Army.js";
+
+const BONUS = 1.4;
+
+// Trinity's three-in-a-row kernels — alignment is the same idea, but
+// commitment is smarter (per-target sizing, not blanket strength-1).
+const KERNELS = [
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 0, 1, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+  [
+    [0, 0, 0, 0, 0],
+    [0, 0, 1, 0, 0],
+    [0, 1, 0, 1, 0],
+    [0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0],
+  ],
+];
+
+const OFFSETS = KERNELS.map((k) => {
+  const out = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const w = k[i][j];
+      if (w !== 0) out.push(i * 5 + j, w);
+    }
+  }
+  return out;
+});
+
+export default {
+  name: "Conqueror",
+  author: "claude",
+  version: 1,
+  description: "Trinity alignment with target-aware commitment (no waste on full friendlies or soft enemies).",
+  summary: `Trinity wins the meta because three-in-a-row alignment compounds —
+but Trinity dumps strength-1 every tick into whichever direction wins the
+convolution, even if that tile is already a maxed-out friendly (waste) or
+a 0.5-strength enemy (massive overkill). Conqueror keeps the alignment
+score — same kernels — but sizes the commitment to the target:
+  - friendly target: send only enough to bring it toward parity (balanced)
+  - empty target: send strength-1 (maximize the new tile)
+  - beatable enemy: send enemy/1.4 + small margin (uses 1.4x attacker bonus)
+  - unbeatable enemy: skip and pick the next-best aligned direction
+This recovers the strength Trinity wastes capping-out friendly tiles, which
+compounds across the match. Same emergent flocking, fewer leaks.`,
+  act(army) {
+    const tile = army.tile;
+    if (!tile || !tile.stencil5) return;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const sLimit = army.strength - 1;
+    if (sLimit <= 0.5) return;
+
+    // Sort directions by alignment score, then walk that order looking for
+    // a viable target. This lets a "second-best" direction win when the
+    // top one is blocked by a maxed friendly or an unbeatable enemy.
+    const ranked = [];
+    for (let k = 0; k < 4; k++) {
+      if (!neighbors[k]) continue;
+      const offs = OFFSETS[k];
+      let score = 0;
+      for (let n = 0; n < offs.length; n += 2) {
+        const t = stencil[offs[n]];
+        if (!t) continue;
+        score += offs[n + 1] * sumStrength(t.armies, viewer);
+      }
+      ranked.push([score, k]);
+    }
+    ranked.sort((a, b) => b[0] - a[0]);
+
+    for (let r = 0; r < ranked.length; r++) {
+      const dir = ranked[r][1];
+      const target = neighbors[dir];
+      const armies = target.armies;
+
+      let friendlyArmy = null;
+      let enemy = 0;
+      for (let i = 0; i < armies.length; i++) {
+        const a = armies[i];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
+      }
+
+      // Friendly tile: balance toward parity, but skip if it's near-cap.
+      if (friendlyArmy) {
+        const cap = friendlyArmy.maxStrength;
+        if (friendlyArmy.strength >= cap - 0.5) continue;
+        const room = cap - friendlyArmy.strength;
+        const want = (army.strength - friendlyArmy.strength) / 2;
+        const power = Math.min(sLimit, room, Math.max(0.6, want));
+        if (power > 0.5) {
+          army.attack(target, power);
+          return;
+        }
+        continue;
+      }
+
+      // Enemy tile: minimum-kill via attacker bonus.
+      if (enemy > 0) {
+        const needed = enemy / BONUS + 0.6;
+        if (needed > sLimit) continue;
+        army.attack(target, needed);
+        return;
+      }
+
+      // Empty tile: take it with what we've got.
+      army.attack(target, sLimit);
+      return;
+    }
+  },
+};

--- a/src/strategies/Crusader.js
+++ b/src/strategies/Crusader.js
@@ -1,0 +1,75 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+const BONUS = 1.4;
+
+// Engine attackerBonus is 1.4. To kill an enemy stack of E, an attacker only
+// needs strength S such that S * 1.4 > E. Most existing bots — including
+// Vampire (sends E+1) and Aggressive (sends s-1) — over-commit on soft
+// targets. Crusader exploits the bonus on every enemy commit, then pushes
+// hard into empty space when there's nothing to kill.
+export default {
+  name: "Crusader",
+  author: "claude",
+  version: 1,
+  description: "Minimum-overkill kills (1.4x bonus aware), aggressive empty-tile expansion otherwise.",
+  summary: `Vampire-style minimum-overkill, but calibrated to the engine's 1.4x
+attacker bonus: a P-strength attack effectively fights as 1.4 P, so we
+only need ceil(E/1.4 + 0.6) to win cleanly. The home tile keeps ~30%
+more strength than Vampire and that surplus is reinvested. When no enemy
+is beatable, we fall through to a strong expansion: hit the weakest
+adjacent enemy if we still can, otherwise grab an empty tile with
+strength-1, otherwise SlowAndSteady reinforce. The thesis is that
+minimum-overkill is only worthwhile if you actually spend the saved
+strength elsewhere — so the fallbacks are tuned to keep the army
+moving instead of standing pat.`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const sLimit = army.strength - 1;
+    if (sLimit <= 0.5) return;
+
+    // Pass 1: pick the weakest beatable enemy (min-overkill the kill).
+    let killTile = null;
+    let killPower = 0;
+    let killEnemy = Infinity;
+    let emptyTile = null;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) {
+        if (!emptyTile) emptyTile = t;
+        continue;
+      }
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendly = true;
+        else enemy += a.strength;
+      }
+      if (friendly || enemy <= 0) continue;
+      const needed = enemy / BONUS + 0.6;
+      if (needed > sLimit) continue;
+      if (enemy < killEnemy) {
+        killEnemy = enemy;
+        killTile = t;
+        killPower = needed;
+      }
+    }
+    if (killTile) {
+      army.attack(killTile, killPower);
+      return;
+    }
+    // Empty tile expansion: send the whole army (minus 1) to plant a strong
+    // forward base. Beats SlowAndSteady's half-measures into empties.
+    if (emptyTile) {
+      army.attack(emptyTile, sLimit);
+      return;
+    }
+    // No kill, no empty: thicken via balanced reinforcement.
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Stalker.js
+++ b/src/strategies/Stalker.js
@@ -1,0 +1,133 @@
+import { sumStrength } from "../core/Army.js";
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+
+// Stencil5 cell -> cardinal direction (W=0, E=1, N=2, S=3) of the dominant
+// axis. Center cell has no direction.
+const DIR_HINT = (() => {
+  const out = new Array(25);
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const dy = i - 2;
+      const dx = j - 2;
+      if (dx === 0 && dy === 0) { out[i * 5 + j] = -1; continue; }
+      if (Math.abs(dx) >= Math.abs(dy)) out[i * 5 + j] = dx < 0 ? 0 : 1;
+      else out[i * 5 + j] = dy < 0 ? 2 : 3;
+    }
+  }
+  return out;
+})();
+
+export default {
+  name: "Stalker",
+  author: "claude",
+  version: 1,
+  description: "Conqueror that proactively pursues the weakest enemy in its 5x5 view.",
+  summary: `Vampire only sees its four neighbors and waits for prey to wander
+in. Hunter scans the 5x5 view but commits blindly toward the densest
+enemy mass and dies to anything fatter than itself. Stalker splits the
+two: prefer Conqueror behavior at the front (minimum-overkill kills,
+empty grabs, friendly balance), but in the absence of an immediate
+move, look at the 5x5 stencil for the *weakest* beatable enemy tile —
+not the densest — and step toward it. Tracking weak prey is the right
+heuristic: those are the tiles where a 1.4x-bonus kill turns into pure
+profit, while dense enemy clusters are a problem we'd rather route
+around. The stalker advances on the soft target, captures it, then
+re-evaluates — a single bot effectively running its own kill chain.`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const sLimit = army.strength - 1;
+
+    // If Conqueror has any viable adjacent move (free kill, empty, or
+    // balanceable friendly), let it handle the tick. We only override
+    // when *all* immediate options are blocked or pointless.
+    let hasAdjacentTarget = false;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) { hasAdjacentTarget = true; break; }
+      let friendlyArmy = null;
+      let enemy = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
+      }
+      if (enemy > 0) {
+        const needed = enemy / BONUS + 0.6;
+        if (needed <= sLimit) { hasAdjacentTarget = true; break; }
+        continue;
+      }
+      if (friendlyArmy && friendlyArmy.strength < friendlyArmy.maxStrength - 0.5) {
+        hasAdjacentTarget = true;
+        break;
+      }
+    }
+    if (hasAdjacentTarget) {
+      Conqueror.act(army, game);
+      return;
+    }
+
+    // Interior or stalled — look 2 deep for the weakest beatable enemy and
+    // pump strength toward them along its dominant axis.
+    if (!tile.stencil5 || sLimit <= 0.5) return;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+
+    let bestDir = -1;
+    let bestEnemy = Infinity;
+    let bestDist = 0;
+    for (let i = 0; i < 25; i++) {
+      const dir = DIR_HINT[i];
+      if (dir < 0) continue;
+      const t = stencil[i];
+      if (!t) continue;
+      const enemy = -sumStrength(t.armies, viewer);
+      if (enemy <= 0) continue;
+      // Beatable check — even from afar, our strength has to matter once we
+      // arrive. Be a little more permissive than the adjacent gate to
+      // account for growth on the way.
+      if (enemy / BONUS > sLimit + 0.5) continue;
+      // Prefer weakest, breaking ties by closest.
+      const dy = (i / 5) | 0;
+      const dx = i - dy * 5;
+      const dist = Math.abs(dx - 2) + Math.abs(dy - 2);
+      if (enemy < bestEnemy || (enemy === bestEnemy && dist < bestDist)) {
+        bestEnemy = enemy;
+        bestDist = dist;
+        bestDir = dir;
+      }
+    }
+    if (bestDir < 0) return;
+    const target = neighbors[bestDir];
+    if (!target) return;
+    const tArmies = target.armies;
+    let friendlyArmy = null;
+    let enemy = 0;
+    for (let k = 0; k < tArmies.length; k++) {
+      const a = tArmies[k];
+      if (a.player.id === pid) friendlyArmy = a;
+      else enemy += a.strength;
+    }
+    if (enemy > 0) {
+      const needed = enemy / BONUS + 0.6;
+      if (needed > sLimit) return;
+      army.attack(target, needed);
+      return;
+    }
+    if (friendlyArmy) {
+      if (friendlyArmy.strength >= friendlyArmy.maxStrength - 0.5) return;
+      const room = friendlyArmy.maxStrength - friendlyArmy.strength;
+      const power = Math.min(sLimit, room);
+      if (power > 0.5) army.attack(target, power);
+      return;
+    }
+    // Empty step toward distant prey.
+    army.attack(target, sLimit);
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -18,6 +18,10 @@ import Avalanche from "./Avalanche.js";
 import Bully from "./Bully.js";
 import Adaptive from "./Adaptive.js";
 import Membrane from "./Membrane.js";
+import Crusader from "./Crusader.js";
+import Conqueror from "./Conqueror.js";
+import Stalker from "./Stalker.js";
+import Citadel from "./Citadel.js";
 import { GENERATED } from "./generated.js";
 import { ARCHIVED } from "./archive.js";
 
@@ -44,6 +48,10 @@ export const ALL_STRATEGY_LIST = [
   Bully,
   Adaptive,
   Membrane,
+  Crusader,
+  Conqueror,
+  Stalker,
+  Citadel,
   ...GENERATED,
 ];
 


### PR DESCRIPTION
## Summary
This PR introduces four new strategy bots that improve upon existing strategies by leveraging the engine's 1.4x attacker bonus more effectively and implementing smarter tactical decision-making.

## Key Changes

- **Crusader**: A minimum-overkill killer that exploits the 1.4x attacker bonus to reduce over-commitment on soft targets. Falls back to aggressive empty-tile expansion when no enemies are beatable, keeping the army mobile rather than static.

- **Conqueror**: An alignment-based strategy (similar to Trinity) that uses the same three-in-a-row kernels but with target-aware commitment sizing. Instead of blindly sending strength-1 in the best-aligned direction, it:
  - Sends only enough to balance friendly tiles toward parity
  - Sends strength-1 to empty tiles
  - Uses minimum-overkill (enemy/1.4 + margin) for beatable enemies
  - Skips unbeatable enemies and tries the next-best aligned direction

- **Stalker**: A hybrid strategy that prefers Conqueror behavior for immediate adjacent moves, but when blocked, scans the 5x5 stencil for the weakest beatable enemy (not the densest) and pursues it. This targets high-profit kills where the 1.4x bonus turns into pure gain, while routing around dense enemy clusters.

- **Citadel**: An adaptive wrapper around Conqueror that adds a consolidation mode. When outnumbered locally (adjacent enemy mass > strength × 1.4), it bleeds surplus strength into the fattest friendly neighbor to build a stack that can fight back. Returns to normal Conqueror behavior once the threat passes.

## Implementation Details

- All strategies properly account for the 1.4x attacker bonus in their kill calculations
- Crusader and Conqueror integrate with existing strategies (SlowAndSteady, Trinity-style kernels)
- Stalker uses a pre-computed `DIR_HINT` lookup table to efficiently map 5x5 stencil positions to cardinal directions
- Citadel demonstrates adaptive behavior by switching modes based on local threat assessment
- All new strategies are registered in the strategy index for inclusion in the bot pool

https://claude.ai/code/session_019ebZL3TE7bYrtnYauwm9t9