### PR TITLE
Add tile tooltip and improve army strength visualization

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -268,10 +268,12 @@ class App {
     this._canvasBound = true;
     this.canvas.addEventListener("mousemove", (e) => {
       this.renderer.hoverTile = this.renderer.pixelToTile(e.clientX, e.clientY);
+      this.updateTileTooltip(e.clientX, e.clientY);
       this.markDirty();
     });
     this.canvas.addEventListener("mouseleave", () => {
       this.renderer.hoverTile = null;
+      this.hideTileTooltip();
       this.markDirty();
     });
     this.canvas.addEventListener("click", (e) => {
@@ -284,6 +286,52 @@ class App {
       }
       this.markDirty();
     });
+  }
+
+  ensureTileTooltip() {
+    if (this._tileTooltip) return this._tileTooltip;
+    const el = document.createElement("div");
+    el.className = "tile-tooltip";
+    el.style.display = "none";
+    document.body.appendChild(el);
+    this._tileTooltip = el;
+    return el;
+  }
+
+  updateTileTooltip(clientX, clientY) {
+    const tile = this.renderer.hoverTile;
+    if (!tile || !tile.armies || tile.armies.length === 0) {
+      this.hideTileTooltip();
+      return;
+    }
+    const el = this.ensureTileTooltip();
+    const rows = tile.armies
+      .filter((a) => a.alive)
+      .map((a) => {
+        const s = a.strength.toFixed(1);
+        const max = a.maxStrength;
+        const pct = Math.round((a.strength / a.maxStrength) * 100);
+        return `<div class="tile-tooltip-row"><span class="tile-tooltip-dot" style="background:${a.player.color}"></span><span class="tile-tooltip-name">${a.player.name}</span><span class="tile-tooltip-num">${s} / ${max} <span class="tile-tooltip-dim">(${pct}%)</span></span></div>`;
+      })
+      .join("");
+    if (!rows) {
+      this.hideTileTooltip();
+      return;
+    }
+    el.innerHTML = `<div class="tile-tooltip-head">Tile (${tile.pos.x}, ${tile.pos.y})</div>${rows}`;
+    el.style.display = "block";
+    const pad = 14;
+    const rect = el.getBoundingClientRect();
+    let x = clientX + pad;
+    let y = clientY + pad;
+    if (x + rect.width > window.innerWidth - 4) x = clientX - rect.width - pad;
+    if (y + rect.height > window.innerHeight - 4) y = clientY - rect.height - pad;
+    el.style.left = `${Math.max(4, x)}px`;
+    el.style.top = `${Math.max(4, y)}px`;
+  }
+
+  hideTileTooltip() {
+    if (this._tileTooltip) this._tileTooltip.style.display = "none";
   }
 
   setActivePlayer(player) {

--- a/src/render/Renderer.js
+++ b/src/render/Renderer.js
@@ -95,18 +95,18 @@ export class Renderer {
   drawArmies(now) {
     const ctx = this.ctx;
     const ts = this.tileSize;
-    // Radius (not diameter) as a fraction of the tile. Area scales
-    // linearly with strength so the circle's visible bulk matches
-    // intuition; sqrt avoids the tiny-army-looks-huge effect that
-    // pure linear-radius scaling produces. minRadius keeps weak
-    // armies clearly visible.
-    const minRadius = 0.22;
+    // Radius scales as ratio^0.7 — between area-linear (sqrt) and
+    // diameter-linear (linear). A 10x strength change yields ~3x
+    // diameter / ~9x area, big enough to read at a glance without
+    // making weak armies invisible.
+    const minRadius = 0.08;
     const maxRadius = 0.46;
+    const exponent = 0.7;
     for (const army of this.game.armies) {
       if (!army.alive) continue;
       if (!army.bornAt) army.bornAt = now;
       const ratio = Math.max(0, Math.min(1, army.strength / army.maxStrength));
-      const radiusFactor = minRadius + (maxRadius - minRadius) * Math.sqrt(ratio);
+      const radiusFactor = minRadius + (maxRadius - minRadius) * Math.pow(ratio, exponent);
       const cx = (army.pos.x + 0.5) * ts;
       const cy = (army.pos.y + 0.5) * ts;
       const age = (now - army.bornAt) / 1000;

--- a/src/render/Renderer.js
+++ b/src/render/Renderer.js
@@ -95,28 +95,36 @@ export class Renderer {
   drawArmies(now) {
     const ctx = this.ctx;
     const ts = this.tileSize;
+    // Radius (not diameter) as a fraction of the tile. Area scales
+    // linearly with strength so the circle's visible bulk matches
+    // intuition; sqrt avoids the tiny-army-looks-huge effect that
+    // pure linear-radius scaling produces. minRadius keeps weak
+    // armies clearly visible.
+    const minRadius = 0.22;
+    const maxRadius = 0.46;
     for (const army of this.game.armies) {
       if (!army.alive) continue;
       if (!army.bornAt) army.bornAt = now;
-      const ratio = army.strength / army.maxStrength;
-      const size = ts * (0.4 + 0.55 * ratio);
+      const ratio = Math.max(0, Math.min(1, army.strength / army.maxStrength));
+      const radiusFactor = minRadius + (maxRadius - minRadius) * Math.sqrt(ratio);
       const cx = (army.pos.x + 0.5) * ts;
       const cy = (army.pos.y + 0.5) * ts;
       const age = (now - army.bornAt) / 1000;
       const pulse = 1 + Math.sin(age * 4 + army.id) * 0.04;
-      const drawSize = size * pulse;
+      const drawRadius = ts * radiusFactor * pulse;
 
       if (this.showGlow) {
-        const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, drawSize);
+        const glowR = drawRadius * 2;
+        const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, glowR);
         grad.addColorStop(0, hexToRgba(army.player.accent, 0.85));
         grad.addColorStop(1, hexToRgba(army.player.color, 0));
         ctx.fillStyle = grad;
-        ctx.fillRect(cx - drawSize, cy - drawSize, drawSize * 2, drawSize * 2);
+        ctx.fillRect(cx - glowR, cy - glowR, glowR * 2, glowR * 2);
       }
 
       ctx.fillStyle = army.player.color;
       ctx.beginPath();
-      ctx.arc(cx, cy, drawSize / 2, 0, Math.PI * 2);
+      ctx.arc(cx, cy, drawRadius, 0, Math.PI * 2);
       ctx.fill();
 
       ctx.strokeStyle = army.player.accent;

--- a/styles.css
+++ b/styles.css
@@ -296,6 +296,62 @@ select.dropdown {
   white-space: pre-wrap;
 }
 
+.tile-tooltip {
+  position: fixed;
+  background: var(--bg-1);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 12px;
+  line-height: 1.4;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+  z-index: 1000;
+  min-width: 160px;
+}
+
+.tile-tooltip-head {
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+  font-weight: 700;
+}
+
+.tile-tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tile-tooltip-row + .tile-tooltip-row {
+  margin-top: 3px;
+}
+
+.tile-tooltip-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  box-shadow: 0 0 6px currentColor;
+}
+
+.tile-tooltip-name {
+  font-weight: 600;
+  flex: 1;
+}
+
+.tile-tooltip-num {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--text);
+}
+
+.tile-tooltip-dim {
+  color: var(--text-dim);
+}
+
 .player-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
This PR adds an interactive tooltip that displays army information when hovering over tiles, and refines the visual representation of army strength on the canvas.

## Key Changes

- **Tile Tooltip UI**: Added new CSS classes (`.tile-tooltip`, `.tile-tooltip-head`, `.tile-tooltip-row`, `.tile-tooltip-dot`, `.tile-tooltip-name`, `.tile-tooltip-num`, `.tile-tooltip-dim`) to style a fixed-position tooltip that appears on hover
- **Tooltip Functionality**: Implemented `updateTileTooltip()`, `hideTileTooltip()`, and `ensureTileTooltip()` methods in the App class to manage tooltip creation, positioning, and content
- **Hover Tracking**: Connected canvas mousemove and mouseleave events to update and hide the tooltip, displaying tile coordinates and all alive armies with their strength values and percentages
- **Army Strength Visualization**: Refactored army radius calculation to use a power-law scaling (exponent 0.7) instead of linear scaling, providing better visual distinction between armies while keeping weak armies visible
- **Tooltip Positioning**: Implemented smart positioning logic that keeps the tooltip within viewport bounds by adjusting placement when it would overflow

## Implementation Details

- The tooltip displays tile coordinates and lists each alive army with a colored dot indicator, player name, current/max strength, and health percentage
- Army radius now scales as `minRadius + (maxRadius - minRadius) * ratio^0.7`, where a 10x strength change yields approximately 3x diameter change
- The tooltip uses `pointer-events: none` to avoid interfering with canvas interactions and has a z-index of 1000 to appear above other content
- Tooltip positioning includes 14px padding from cursor and 4px minimum margin from viewport edges

https://claude.ai/code/session_01LZf644Tx3BPxQwjVhHyGS5