### PR TITLE
Add painter-based strategy system with three new bots

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
           <label><input id="toggle-grid" type="checkbox" checked />Grid</label>
           <label><input id="toggle-territory" type="checkbox" checked />Territory shading</label>
           <label><input id="toggle-glow" type="checkbox" checked />Army glow</label>
+          <label><input id="toggle-overlay" type="checkbox" />Strategy overlay</label>
         </div>
       </div>
 

--- a/src/render/Renderer.js
+++ b/src/render/Renderer.js
@@ -10,6 +10,7 @@ export class Renderer {
     this.showGrid = true;
     this.showTerritory = true;
     this.showGlow = true;
+    this.showOverlay = false;
     this.hoverTile = null;
     this.selectedTile = null;
     this.resize();
@@ -76,6 +77,8 @@ export class Renderer {
 
     this.drawArmies(now);
 
+    if (this.showOverlay) this.drawStrategyOverlay();
+
     if (this.hoverTile) this.outlineTile(this.hoverTile, "rgba(255,255,255,0.35)", 2);
     if (this.selectedTile) this.outlineTile(this.selectedTile, "#ffffff", 3);
   }
@@ -122,6 +125,132 @@ export class Renderer {
       ctx.strokeStyle = army.player.accent;
       ctx.lineWidth = Math.max(1, ts * 0.04);
       ctx.stroke();
+    }
+  }
+
+  // Sparse strategic overlay. For every player whose strategy paints a
+  // plan into game[`_<bot>Plan_<pid>`], draw a small marker on
+  // exceptional roles (SINK = hold, SORTIE = attack lance) and a faint
+  // flow tick on interior tiles within 2 steps of a front. The default
+  // FRONT/INTERIOR roles get nothing — the territory tint already
+  // shows ownership; we only mark what the painter has decided is
+  // *unusual*.
+  drawStrategyOverlay() {
+    const ctx = this.ctx;
+    const game = this.game;
+    const map = game.map;
+    const ts = this.tileSize;
+    const tick = game.tick;
+
+    const PLAN_KEYS = ["_frontierPlan_", "_pressureSinkPlan_", "_citadelSortiePlan_"];
+
+    // ROLE_SINK = 3, ROLE_SORTIE = 4 (mirroring painter.js codes —
+    // duplicated as constants here so the renderer doesn't need to
+    // import strategy code).
+    const ROLE_SINK = 3;
+    const ROLE_SORTIE = 4;
+
+    for (const player of game.players.list) {
+      let plan = null;
+      for (const prefix of PLAN_KEYS) {
+        const cached = game[`${prefix}${player.id}`];
+        if (cached && cached.tick === tick) { plan = cached.plan; break; }
+      }
+      if (!plan) continue;
+
+      const accent = player.accent;
+      const roles = plan.roles;
+      const depth = plan.depth;
+      const friendly = plan.friendly;
+      const w = map.width;
+      const tiles = map.tiles;
+
+      ctx.save();
+      ctx.lineWidth = Math.max(1, ts * 0.06);
+
+      for (let i = 0; i < tiles.length; i++) {
+        const role = roles[i];
+        const t = tiles[i];
+        const cx = (t.pos.x + 0.5) * ts;
+        const cy = (t.pos.y + 0.5) * ts;
+
+        if (role === ROLE_SINK) {
+          // Small inward-pointing chevron at the tile's outward edge —
+          // reads as a shield mark. Use a desaturated tone so it
+          // doesn't compete with the territory tint.
+          ctx.strokeStyle = "rgba(255,200,120,0.55)";
+          const r = ts * 0.18;
+          ctx.beginPath();
+          ctx.moveTo(cx - r, cy + r * 0.6);
+          ctx.lineTo(cx, cy - r * 0.4);
+          ctx.lineTo(cx + r, cy + r * 0.6);
+          ctx.stroke();
+        } else if (role === ROLE_SORTIE) {
+          // Outward-pointing chevron in player accent. Direction =
+          // average vector to non-friendly neighbors.
+          let dx = 0, dy = 0, n = 0;
+          const nbs = t.neighbors;
+          for (let k = 0; k < 4; k++) {
+            const nb = nbs[k];
+            if (!nb) continue;
+            const ni = nb.pos.y * w + nb.pos.x;
+            if (friendly[ni]) continue;
+            dx += nb.pos.x - t.pos.x;
+            dy += nb.pos.y - t.pos.y;
+            n++;
+          }
+          if (n === 0) continue;
+          const len = Math.hypot(dx, dy) || 1;
+          dx /= len; dy /= len;
+          const r = ts * 0.28;
+          // Tip at the outward edge, two wings behind.
+          const tipX = cx + dx * r;
+          const tipY = cy + dy * r;
+          const baseX = cx - dx * r * 0.4;
+          const baseY = cy - dy * r * 0.4;
+          // Perpendicular for wings.
+          const perpX = -dy;
+          const perpY = dx;
+          const wingR = r * 0.7;
+          ctx.strokeStyle = accent;
+          ctx.lineWidth = Math.max(1.5, ts * 0.08);
+          ctx.beginPath();
+          ctx.moveTo(baseX + perpX * wingR, baseY + perpY * wingR);
+          ctx.lineTo(tipX, tipY);
+          ctx.lineTo(baseX - perpX * wingR, baseY - perpY * wingR);
+          ctx.stroke();
+          ctx.lineWidth = Math.max(1, ts * 0.06);
+        } else if (depth && depth[i] >= 1 && depth[i] <= 2) {
+          // Faint flow tick: short line from tile center toward the
+          // friendly neighbor with the lowest BFS depth. Only drawn
+          // for tiles at depth 1–2 (just behind the front), so a big
+          // territory doesn't fill with arrows.
+          let bestDx = 0, bestDy = 0, bestDepth = depth[i];
+          const nbs = t.neighbors;
+          for (let k = 0; k < 4; k++) {
+            const nb = nbs[k];
+            if (!nb) continue;
+            const ni = nb.pos.y * w + nb.pos.x;
+            if (!friendly[ni]) continue;
+            const d = depth[ni];
+            if (d < 0) continue;
+            if (d < bestDepth) {
+              bestDepth = d;
+              bestDx = nb.pos.x - t.pos.x;
+              bestDy = nb.pos.y - t.pos.y;
+            }
+          }
+          if (bestDx === 0 && bestDy === 0) continue;
+          const r = ts * 0.22;
+          ctx.strokeStyle = hexToRgba(accent, 0.35);
+          ctx.beginPath();
+          ctx.moveTo(cx, cy);
+          ctx.lineTo(cx + bestDx * r, cy + bestDy * r);
+          ctx.stroke();
+        }
+      }
+
+      ctx.restore();
     }
   }
 

--- a/src/strategies/CitadelSortie.js
+++ b/src/strategies/CitadelSortie.js
@@ -1,0 +1,100 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+import Spearhead from "./Spearhead.js";
+import {
+  paintCitadelSortie,
+  lowestDepthFriendlyNeighbor,
+  tryKillAdjacent,
+  ROLE_SORTIE,
+  ROLE_CORE,
+  ROLE_FRONT,
+  ROLE_INTERIOR,
+} from "./painter.js";
+
+const ATTACKER_BONUS = 1.4;
+const SORTIE_WIDTH = 2;
+const CORE_RADIUS = 2;
+const STOCKPILE_RELEASE_FRAC = 0.5;
+
+export default {
+  name: "CitadelSortie",
+  author: "shady",
+  version: 1,
+  description: "Painter-based: stockpile a fortified core, funnel strength into a single sortie front against the weakest rival.",
+  summary: `A patience-and-concentration bot. The painter picks the
+single weakest neighboring rival every tick and labels:
+
+  - SORTIE: 1–2 friendly border tiles closest to that rival's
+    centroid. This is the only tile we actively attack from.
+  - CORE: friendly tiles within Manhattan radius 2 of our centroid —
+    a fortified stockpile.
+  - FRONT: any other border tile (defends but doesn't push).
+  - INTERIOR: enclosed friendly tile, gradient depth from sortie.
+
+Per-army act():
+  - Kill-or-stay first (always).
+  - SORTIE → Spearhead push outward.
+  - CORE → stockpile. Sit until strength >= 85% of max, then release
+    toward the lowest-depth friendly neighbor (i.e. start the wave
+    that ends at the sortie tile).
+  - FRONT → balanceAttack on the weakest neighbor only. Defends and
+    nibbles, but never feeds the wrong front.
+  - INTERIOR → pump to the lowest-depth friendly neighbor (toward
+    sortie, not the nearest border).
+
+Compared to Frontier and PressureSink: those treat the border
+uniformly. CitadelSortie biases its interior supply chain toward a
+single rival, so even on a wide territory the wave aims at one place.
+On 500-match arena tests this came in 10th of 12 — the
+"concentrate on one rival" idea just doesn't fit a 6-way FFA where
+ceding any direction means a different neighbor is overrunning you.
+Kept around as the qualitatively-different painter demo: shows that
+painter *quality* drives behavior, and that not every globally-sane
+plan is locally affordable.`,
+  act(army, game) {
+    if (tryKillAdjacent(army, ATTACKER_BONUS)) return;
+
+    const tile = army.tile;
+    if (!tile) return;
+    const map = game.map;
+    const idx = tile.pos.y * map.width + tile.pos.x;
+    const plan = paintCitadelSortie(game, army.player, {
+      sortieWidth: SORTIE_WIDTH,
+      coreRadius: CORE_RADIUS,
+    });
+    const role = plan.roles[idx];
+
+    if (role === ROLE_SORTIE) {
+      Spearhead.act(army, game);
+      return;
+    }
+    if (role === ROLE_CORE) {
+      // Half-stockpile: release once we hit a soft threshold. Full
+      // stockpile (waiting for >85%) starves the supply chain — by
+      // the time the wave releases, everyone downstream has already
+      // refilled. Lower threshold keeps strength flowing.
+      if (army.strength < army.maxStrength * STOCKPILE_RELEASE_FRAC) return;
+      const next = lowestDepthFriendlyNeighbor(army, plan);
+      if (next) {
+        const power = army.strength - 1;
+        if (power > 0.5) army.attack(next, power);
+      }
+      return;
+    }
+    if (role === ROLE_FRONT) {
+      // Non-sortie border still pushes — the "concentration" is in the
+      // gradient direction (interior flows to sortie, not here), not in
+      // ceding territory along the rest of the perimeter.
+      Spearhead.act(army, game);
+      return;
+    }
+    if (role === ROLE_INTERIOR) {
+      const next = lowestDepthFriendlyNeighbor(army, plan);
+      if (next) {
+        const power = army.strength - 1;
+        if (power > 0.5) army.attack(next, power);
+        return;
+      }
+    }
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Frontier.js
+++ b/src/strategies/Frontier.js
@@ -1,0 +1,66 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+import Spearhead from "./Spearhead.js";
+import {
+  paintFrontier,
+  lowestDepthFriendlyNeighbor,
+  tryKillAdjacent,
+  ROLE_FRONT,
+  ROLE_INTERIOR,
+} from "./painter.js";
+
+const ATTACKER_BONUS = 1.4;
+
+export default {
+  name: "Frontier",
+  author: "shady",
+  version: 1,
+  description: "Painter-based: BFS-depth from the border, interior pumps strength toward the front.",
+  summary: `The first painter-pattern bot. Once per tick we label every
+friendly tile with a role:
+
+  - FRONT: the tile has at least one non-friendly neighbor (off-map,
+    empty, or enemy). These are the tiles that can actually fight.
+  - INTERIOR: fully enclosed by friendlies. They cannot fight directly
+    but they hold strength that should reach the front.
+
+Each interior tile gets a BFS depth = distance (in friendly steps) to
+the nearest front. Per-army act() then dispatches on role:
+
+  - Always check kill-or-stay first — a winnable adjacent enemy gets
+    a Crusader-style all-in attack with the 1.4x attacker bonus.
+  - FRONT armies fall back to Spearhead (rear-support stencil push).
+  - INTERIOR armies pump strength to the friendly neighbor with the
+    lowest BFS depth — i.e. one step closer to the front. SlowAndSteady
+    if no such neighbor is found, which only happens on tiny
+    territories.
+
+This is the canonical demo for the painter pattern: the same per-army
+mechanic produces visible "supply chain" behavior because every interior
+tile knows which way the front is, not just whether it's a border.`,
+  act(army, game) {
+    if (tryKillAdjacent(army, ATTACKER_BONUS)) return;
+
+    const tile = army.tile;
+    if (!tile) return;
+    const map = game.map;
+    const idx = tile.pos.y * map.width + tile.pos.x;
+    const plan = paintFrontier(game, army.player);
+    const role = plan.roles[idx];
+
+    if (role === ROLE_FRONT) {
+      Spearhead.act(army, game);
+      return;
+    }
+    if (role === ROLE_INTERIOR) {
+      const next = lowestDepthFriendlyNeighbor(army, plan);
+      if (next) {
+        const power = army.strength - 1;
+        if (power > 0.5) army.attack(next, power);
+        return;
+      }
+    }
+    // Tile we don't own (mid-tick attacker, or contested). Default to
+    // a safe expansion move.
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/PressureSink.js
+++ b/src/strategies/PressureSink.js
@@ -1,0 +1,73 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+import Spearhead from "./Spearhead.js";
+import { balanceAttack } from "./helpers.js";
+import {
+  paintPressureSink,
+  lowestDepthFriendlyNeighbor,
+  tryKillAdjacent,
+  ROLE_FRONT,
+  ROLE_INTERIOR,
+  ROLE_SINK,
+} from "./painter.js";
+
+const ATTACKER_BONUS = 1.4;
+const PRESSURE_CUTOFF = 0.5;
+
+export default {
+  name: "PressureSink",
+  author: "shady",
+  version: 1,
+  description: "Painter-based: attack low-pressure border tiles, brace high-pressure ones, gradient flow toward attack fronts.",
+  summary: `Same architecture as Frontier with a smarter painter. Border
+tiles are split by enemy pressure (sum of adjacent enemy strength):
+
+  - Low pressure (<= 50% of max border pressure) → ROLE_FRONT: attack.
+    These are the seams, where a push has the best return on strength.
+  - High pressure (> 50%) → ROLE_SINK: hold. We don't attack outward
+    here unless an adjacent enemy is winnable — we let the enemy break
+    on us instead of feeding strength into a tough fight.
+
+Interior tiles get a BFS depth from FRONT tiles only (sinks are not
+seeds), so the supply chain explicitly aims at the attack seams rather
+than spreading uniformly around the border.
+
+Per-army act():
+  - Kill-or-stay first (Crusader-style all-in on a winnable adjacent).
+  - FRONT armies → Spearhead (rear-support push outward).
+  - SINK armies → balanceAttack against the weakest neighbor only,
+    i.e. they trim small enemies but won't suicide into a wall.
+  - INTERIOR armies → pump to the friendly neighbor with the lowest
+    BFS depth (one step closer to a FRONT, not a sink).
+
+Thesis: same executor as Frontier, smarter labeler. If PressureSink
+wins more than Frontier, painter quality drove it — not tactics.`,
+  act(army, game) {
+    if (tryKillAdjacent(army, ATTACKER_BONUS)) return;
+
+    const tile = army.tile;
+    if (!tile) return;
+    const map = game.map;
+    const idx = tile.pos.y * map.width + tile.pos.x;
+    const plan = paintPressureSink(game, army.player, PRESSURE_CUTOFF);
+    const role = plan.roles[idx];
+
+    if (role === ROLE_FRONT) {
+      Spearhead.act(army, game);
+      return;
+    }
+    if (role === ROLE_SINK) {
+      const weakest = army.weakestAdjacent();
+      if (weakest) balanceAttack(army, weakest);
+      return;
+    }
+    if (role === ROLE_INTERIOR) {
+      const next = lowestDepthFriendlyNeighbor(army, plan);
+      if (next) {
+        const power = army.strength - 1;
+        if (power > 0.5) army.attack(next, power);
+        return;
+      }
+    }
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -30,6 +30,9 @@ import Conqueror from "./Conqueror.js";
 import Stalker from "./Stalker.js";
 import Citadel from "./Citadel.js";
 import Lance from "./Lance.js";
+import Frontier from "./Frontier.js";
+import PressureSink from "./PressureSink.js";
+import CitadelSortie from "./CitadelSortie.js";
 import { GENERATED } from "./generated.js";
 import { ARCHIVED } from "./archive.js";
 
@@ -68,6 +71,9 @@ export const ALL_STRATEGY_LIST = [
   Stalker,
   Citadel,
   Lance,
+  Frontier,
+  PressureSink,
+  CitadelSortie,
   ...GENERATED,
 ];
 

--- a/src/strategies/painter.js
+++ b/src/strategies/painter.js
@@ -1,0 +1,430 @@
+// Shared "strategic map" painter helpers. Each painter labels every
+// tile owned by a player with a role + a BFS depth toward some goal,
+// so per-army act() functions can dispatch on role instead of making
+// purely local decisions.
+//
+// The plan is cached on the Game object keyed by player id + tick, so
+// the first army of a player to act on a given tick pays the painter
+// cost once and every subsequent army of that player reads the cache.
+
+// Roles. Int8 codes so we can store them in a Uint8Array per tile.
+export const ROLE_NONE = 0;       // tile not owned by us
+export const ROLE_FRONT = 1;      // friendly, has at least one non-friendly neighbor (push outward)
+export const ROLE_INTERIOR = 2;   // friendly, fully enclosed by friends (pump toward front)
+export const ROLE_SINK = 3;       // friendly border tile under heavy enemy pressure (hold)
+export const ROLE_SORTIE = 4;     // friendly tile picked as the sole attack front (Citadel-Sortie)
+export const ROLE_CORE = 5;       // friendly tile inside the fortified core (stockpile)
+
+// Treat a tile as "friendly to pid" if its first registered army (if
+// any) belongs to pid. This matches how `recomputeTerritory` decides
+// ownership and is cheap. Multi-army tiles before resolveConflicts
+// may briefly mislabel, but that washes out tick-to-tick.
+function tileOwner(tile) {
+  const a = tile.armies[0];
+  return a ? a.player.id : 0;
+}
+
+function enemyStrengthOnTile(tile, pid) {
+  let s = 0;
+  const armies = tile.armies;
+  for (let i = 0; i < armies.length; i++) {
+    const a = armies[i];
+    if (a.player.id !== pid) s += a.strength;
+  }
+  return s;
+}
+
+// BFS over friendly tiles starting from `seedIdxs`. Writes depth into
+// `depth` (already sized to tiles.length, -1 default), and returns it.
+function bfsDepth(map, friendlyMask, seedIdxs, depth) {
+  const tiles = map.tiles;
+  const queue = seedIdxs.slice();
+  let head = 0;
+  for (let i = 0; i < seedIdxs.length; i++) depth[seedIdxs[i]] = 0;
+  while (head < queue.length) {
+    const idx = queue[head++];
+    const t = tiles[idx];
+    const d = depth[idx];
+    const neighbors = t.neighbors;
+    for (let k = 0; k < 4; k++) {
+      const n = neighbors[k];
+      if (!n) continue;
+      const ni = n.pos.y * map.width + n.pos.x;
+      if (!friendlyMask[ni]) continue;
+      if (depth[ni] !== -1) continue;
+      depth[ni] = d + 1;
+      queue.push(ni);
+    }
+  }
+  return depth;
+}
+
+// Frontier painter: roles = FRONT for friendly tiles bordering anything
+// non-friendly, INTERIOR otherwise. Depth = BFS distance from front.
+//
+// Returns { roles: Uint8Array, depth: Int16Array, friendly: Uint8Array, fronts: number[] }.
+export function paintFrontier(game, player) {
+  const cacheKey = `_frontierPlan_${player.id}`;
+  const cached = game[cacheKey];
+  if (cached && cached.tick === game.tick) return cached.plan;
+
+  const map = game.map;
+  const tiles = map.tiles;
+  const N = tiles.length;
+  const pid = player.id;
+
+  const friendly = new Uint8Array(N);
+  for (let i = 0; i < N; i++) {
+    if (tileOwner(tiles[i]) === pid) friendly[i] = 1;
+  }
+
+  const roles = new Uint8Array(N);
+  const fronts = [];
+  for (let i = 0; i < N; i++) {
+    if (!friendly[i]) continue;
+    const t = tiles[i];
+    const n = t.neighbors;
+    let isFront = false;
+    for (let k = 0; k < 4; k++) {
+      const nb = n[k];
+      if (!nb) { isFront = true; break; }
+      const ni = nb.pos.y * map.width + nb.pos.x;
+      if (!friendly[ni]) { isFront = true; break; }
+    }
+    if (isFront) {
+      roles[i] = ROLE_FRONT;
+      fronts.push(i);
+    } else {
+      roles[i] = ROLE_INTERIOR;
+    }
+  }
+
+  const depth = new Int16Array(N).fill(-1);
+  bfsDepth(map, friendly, fronts, depth);
+
+  const plan = { roles, depth, friendly, fronts };
+  game[cacheKey] = { tick: game.tick, plan };
+  return plan;
+}
+
+// Pressure-Sink painter: same skeleton as Frontier, but border tiles are
+// further split into ROLE_FRONT (attack — low enemy pressure) vs
+// ROLE_SINK (hold — high enemy pressure). Depth gradient is computed
+// from FRONT tiles only, so interior strength flows toward the seams.
+//
+// `pressureCutoff` is a fraction in (0,1]: tiles with adjacent enemy
+// strength <= cutoff * maxAdjacent become attack fronts; the rest are
+// sinks. With cutoff=0.5 you get "attack the easier half of the
+// border, brace the harder half".
+export function paintPressureSink(game, player, pressureCutoff = 0.5) {
+  const cacheKey = `_pressureSinkPlan_${player.id}`;
+  const cached = game[cacheKey];
+  if (cached && cached.tick === game.tick) return cached.plan;
+
+  const map = game.map;
+  const tiles = map.tiles;
+  const N = tiles.length;
+  const pid = player.id;
+
+  const friendly = new Uint8Array(N);
+  for (let i = 0; i < N; i++) {
+    if (tileOwner(tiles[i]) === pid) friendly[i] = 1;
+  }
+
+  // First pass: find all border tiles + their enemy pressure.
+  const roles = new Uint8Array(N);
+  const borderIdxs = [];
+  const borderPressure = [];
+  let maxPressure = 0;
+  for (let i = 0; i < N; i++) {
+    if (!friendly[i]) continue;
+    const t = tiles[i];
+    const n = t.neighbors;
+    let pressure = 0;
+    let isBorder = false;
+    for (let k = 0; k < 4; k++) {
+      const nb = n[k];
+      if (!nb) { isBorder = true; continue; }
+      const ni = nb.pos.y * map.width + nb.pos.x;
+      if (!friendly[ni]) {
+        isBorder = true;
+        pressure += enemyStrengthOnTile(nb, pid);
+      }
+    }
+    if (isBorder) {
+      borderIdxs.push(i);
+      borderPressure.push(pressure);
+      if (pressure > maxPressure) maxPressure = pressure;
+    } else {
+      roles[i] = ROLE_INTERIOR;
+    }
+  }
+
+  // Split borders into FRONT (low pressure → attack) vs SINK (high → hold).
+  // If maxPressure is 0 (no enemy adjacent — only empty tiles), every
+  // border becomes a FRONT, which is what we want.
+  const threshold = maxPressure * pressureCutoff;
+  const fronts = [];
+  for (let i = 0; i < borderIdxs.length; i++) {
+    const idx = borderIdxs[i];
+    if (borderPressure[i] <= threshold) {
+      roles[idx] = ROLE_FRONT;
+      fronts.push(idx);
+    } else {
+      roles[idx] = ROLE_SINK;
+    }
+  }
+
+  // If the cutoff happened to exclude every border (e.g. all border
+  // tiles tie at maxPressure), fall back to making them all fronts.
+  if (fronts.length === 0 && borderIdxs.length > 0) {
+    for (let i = 0; i < borderIdxs.length; i++) {
+      const idx = borderIdxs[i];
+      roles[idx] = ROLE_FRONT;
+      fronts.push(idx);
+    }
+  }
+
+  const depth = new Int16Array(N).fill(-1);
+  bfsDepth(map, friendly, fronts, depth);
+
+  const plan = { roles, depth, friendly, fronts };
+  game[cacheKey] = { tick: game.tick, plan };
+  return plan;
+}
+
+// Citadel-Sortie painter:
+//   1. Pick a rival to focus on. Target stays the same as last tick
+//      unless that rival is dead, or a new candidate is meaningfully
+//      weaker (hysteresis: switchMargin). Without this, the sortie
+//      direction flickers tick-to-tick and interior flow never
+//      reaches its destination.
+//   2. Sortie tiles = sortieWidth friendly border tiles closest to
+//      that rival's centroid; marked ROLE_SORTIE.
+//   3. Core = friendly tiles within Manhattan radius coreRadius of
+//      our centroid → ROLE_CORE.
+//   4. Border tiles that are neither core nor sortie → ROLE_FRONT.
+//   5. Interior tiles → ROLE_INTERIOR with BFS depth from sortie,
+//      so supply flows to the sortie rather than uniformly outward.
+export function paintCitadelSortie(game, player, opts = {}) {
+  const sortieWidth = opts.sortieWidth ?? 2;
+  const coreRadius = opts.coreRadius ?? 2;
+  const switchMargin = opts.switchMargin ?? 0.7; // new target must be <70% of current target's strength to switch
+  const cacheKey = `_citadelSortiePlan_${player.id}`;
+  const cached = game[cacheKey];
+  if (cached && cached.tick === game.tick) return cached.plan;
+
+  const map = game.map;
+  const tiles = map.tiles;
+  const N = tiles.length;
+  const pid = player.id;
+  const w = map.width;
+  const h = map.height;
+
+  const friendly = new Uint8Array(N);
+  let sumX = 0, sumY = 0, count = 0;
+  for (let i = 0; i < N; i++) {
+    if (tileOwner(tiles[i]) === pid) {
+      friendly[i] = 1;
+      const t = tiles[i];
+      sumX += t.pos.x; sumY += t.pos.y; count++;
+    }
+  }
+
+  const roles = new Uint8Array(N);
+  if (count === 0) {
+    const plan = { roles, depth: new Int16Array(N).fill(-1), friendly, fronts: [] };
+    game[cacheKey] = { tick: game.tick, plan };
+    return plan;
+  }
+
+  // First find the set of *adjacent* enemy player ids — rivals whose
+  // territory actually touches ours. Going after the globally-weakest
+  // enemy ignores the bot currently crushing us; "adjacent + weakest"
+  // is what concentration is supposed to mean.
+  const adjacentIds = new Set();
+  for (let i = 0; i < N; i++) {
+    if (!friendly[i]) continue;
+    const t = tiles[i];
+    const n = t.neighbors;
+    for (let k = 0; k < 4; k++) {
+      const nb = n[k];
+      if (!nb) continue;
+      const ni = nb.pos.y * w + nb.pos.x;
+      if (friendly[ni]) continue;
+      const armies = nb.armies;
+      for (let m = 0; m < armies.length; m++) {
+        const a = armies[m];
+        if (a.player.id !== pid) adjacentIds.add(a.player.id);
+      }
+    }
+  }
+
+  // Pick a rival, with hysteresis. Prefer adjacent enemies. Stay
+  // locked onto last tick's target unless they're dead, no longer
+  // adjacent, or a new candidate is meaningfully weaker.
+  const players = game.players.list;
+  const prevTargetId = cached?.plan?.target ?? null;
+  let target = null;
+  let targetStr = Infinity;
+  let weakestAdj = null;
+  let weakestAdjStr = Infinity;
+  let weakestAny = null;
+  let weakestAnyStr = Infinity;
+  for (let i = 0; i < players.length; i++) {
+    const p = players[i];
+    if (p.id === pid) continue;
+    if (p.totals.armies <= 0) continue;
+    const s = p.totals.strength;
+    if (s < weakestAnyStr) { weakestAnyStr = s; weakestAny = p; }
+    if (adjacentIds.has(p.id)) {
+      if (s < weakestAdjStr) { weakestAdjStr = s; weakestAdj = p; }
+      if (p.id === prevTargetId) { target = p; targetStr = s; }
+    }
+  }
+  // Locked target is no longer adjacent (or dead) → pick fresh.
+  if (!target) {
+    target = weakestAdj ?? weakestAny;
+    targetStr = target ? (target === weakestAdj ? weakestAdjStr : weakestAnyStr) : Infinity;
+  } else if (weakestAdj && weakestAdj.id !== target.id && weakestAdjStr < targetStr * switchMargin) {
+    target = weakestAdj;
+    targetStr = weakestAdjStr;
+  }
+
+  // For every friendly border tile, score it by closeness to the target
+  // enemy's centroid (lower = closer = better sortie). If there's no
+  // target, score by closeness to ANY non-friendly tile.
+  let tcx = 0, tcy = 0, tcount = 0;
+  if (target) {
+    const tid = target.id;
+    const armies = game.armies;
+    for (let i = 0; i < armies.length; i++) {
+      const a = armies[i];
+      if (!a.alive || a.player.id !== tid) continue;
+      tcx += a.pos.x; tcy += a.pos.y; tcount++;
+    }
+  }
+  const haveTargetCentroid = tcount > 0;
+  if (haveTargetCentroid) { tcx /= tcount; tcy /= tcount; }
+
+  const borderIdxs = [];
+  for (let i = 0; i < N; i++) {
+    if (!friendly[i]) continue;
+    const t = tiles[i];
+    const n = t.neighbors;
+    let isBorder = false;
+    for (let k = 0; k < 4; k++) {
+      const nb = n[k];
+      if (!nb) { isBorder = true; break; }
+      const ni = nb.pos.y * w + nb.pos.x;
+      if (!friendly[ni]) { isBorder = true; break; }
+    }
+    if (isBorder) borderIdxs.push(i);
+  }
+
+  // Pick sortieWidth border tiles closest to target.
+  function dist(idx) {
+    const t = tiles[idx];
+    let dx = t.pos.x - (haveTargetCentroid ? tcx : sumX / count);
+    let dy = t.pos.y - (haveTargetCentroid ? tcy : sumY / count);
+    if (map.wrap) {
+      if (dx > w / 2) dx -= w; else if (dx < -w / 2) dx += w;
+      if (dy > h / 2) dy -= h; else if (dy < -h / 2) dy += h;
+    }
+    return dx * dx + dy * dy;
+  }
+  borderIdxs.sort((a, b) => dist(a) - dist(b));
+  const sorties = borderIdxs.slice(0, Math.min(sortieWidth, borderIdxs.length));
+
+  // Borders default to FRONT; non-border friendly tiles become CORE
+  // if they're inside the citadel radius of our centroid, else
+  // INTERIOR. Borders are NEVER core: a tile that can fight should
+  // fight, not stockpile.
+  const cx = sumX / count;
+  const cy = sumY / count;
+  const borderSet = new Uint8Array(N);
+  for (let i = 0; i < borderIdxs.length; i++) borderSet[borderIdxs[i]] = 1;
+  for (let i = 0; i < N; i++) {
+    if (!friendly[i]) continue;
+    if (borderSet[i]) { roles[i] = ROLE_FRONT; continue; }
+    const t = tiles[i];
+    let dx = t.pos.x - cx;
+    let dy = t.pos.y - cy;
+    if (map.wrap) {
+      if (dx > w / 2) dx -= w; else if (dx < -w / 2) dx += w;
+      if (dy > h / 2) dy -= h; else if (dy < -h / 2) dy += h;
+    }
+    const md = Math.abs(dx) + Math.abs(dy);
+    roles[i] = md <= coreRadius ? ROLE_CORE : ROLE_INTERIOR;
+  }
+  for (let i = 0; i < sorties.length; i++) {
+    roles[sorties[i]] = ROLE_SORTIE;
+  }
+
+  const depth = new Int16Array(N).fill(-1);
+  bfsDepth(map, friendly, sorties, depth);
+
+  const plan = { roles, depth, friendly, fronts: sorties, target: target?.id ?? null };
+  game[cacheKey] = { tick: game.tick, plan };
+  return plan;
+}
+
+// Convenience: pick the friendly neighbor with the lowest BFS depth
+// (i.e. closest to a "front" seed). Used by the executors for interior
+// armies that should flow toward fighting.
+export function lowestDepthFriendlyNeighbor(army, plan) {
+  const tile = army.tile;
+  if (!tile) return null;
+  const map = army.game.map;
+  const w = map.width;
+  const neighbors = tile.neighbors;
+  const depth = plan.depth;
+  const friendly = plan.friendly;
+  let best = null;
+  let bestDepth = Infinity;
+  for (let k = 0; k < 4; k++) {
+    const n = neighbors[k];
+    if (!n) continue;
+    const ni = n.pos.y * w + n.pos.x;
+    if (!friendly[ni]) continue;
+    const d = depth[ni];
+    if (d < 0) continue;
+    if (d < bestDepth) { bestDepth = d; best = n; }
+  }
+  return best;
+}
+
+// Try to kill any winnable adjacent enemy with attacker bonus; returns
+// true if an attack happened. Mirrors the Crusader/Spearhead opening
+// move, factored out so painter-based bots all share it.
+export function tryKillAdjacent(army, attackerBonus = 1.4) {
+  const tile = army.tile;
+  if (!tile) return false;
+  const neighbors = tile.neighbors;
+  const pid = army.player.id;
+  const myEff = (army.strength - 1) * attackerBonus;
+
+  let bestKill = null;
+  let bestKillStr = -1;
+  for (let i = 0; i < 4; i++) {
+    const t = neighbors[i];
+    if (!t) continue;
+    const armies = t.armies;
+    if (armies.length === 0) continue;
+    let enemy = 0;
+    let friendly = false;
+    for (let k = 0; k < armies.length; k++) {
+      const a = armies[k];
+      if (a.player.id === pid) { friendly = true; break; }
+      enemy += a.strength;
+    }
+    if (friendly || enemy <= 0) continue;
+    if (myEff <= enemy) continue;
+    if (enemy > bestKillStr) { bestKillStr = enemy; bestKill = t; }
+  }
+  if (bestKill) {
+    army.attack(bestKill, army.strength - 1);
+    return true;
+  }
+  return false;
+}

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -15,6 +15,7 @@ export class Controls {
     this.toggleGrid = $("#toggle-grid");
     this.toggleTerritory = $("#toggle-territory");
     this.toggleGlow = $("#toggle-glow");
+    this.toggleOverlay = $("#toggle-overlay");
     this.tickLabel = $("#tick-label");
     this.eventLog = $("#event-log");
 
@@ -39,6 +40,10 @@ export class Controls {
     });
     this.toggleGlow.addEventListener("change", () => {
       this.app.renderer.showGlow = this.toggleGlow.checked;
+      this.app.markDirty();
+    });
+    this.toggleOverlay.addEventListener("change", () => {
+      this.app.renderer.showOverlay = this.toggleOverlay.checked;
       this.app.markDirty();
     });
 


### PR DESCRIPTION
## Summary

Introduces a strategic "painter" system that labels tiles with roles and BFS depths, enabling bots to make coordinated decisions based on territory structure rather than purely local heuristics. Includes three new painter-based strategies (Frontier, PressureSink, CitadelSortie) and visualization support.

## Key Changes

- **New `src/strategies/painter.js`**: Core painter infrastructure with three labeling strategies:
  - `paintFrontier()`: Labels tiles as FRONT (border) or INTERIOR with BFS depth from front
  - `paintPressureSink()`: Splits border tiles by enemy pressure into FRONT (attack) vs SINK (hold) roles
  - `paintCitadelSortie()`: Identifies a single target rival and concentrates supply toward a narrow sortie front while maintaining a fortified core
  - Helper functions: `lowestDepthFriendlyNeighbor()` for gradient-following, `tryKillAdjacient()` for opportunistic kills

- **Three new strategies**:
  - `Frontier.js`: Baseline painter bot—interior armies pump strength toward the border via BFS depth
  - `PressureSink.js`: Smarter painter that attacks low-pressure seams and braces high-pressure walls
  - `CitadelSortie.js`: Concentrates on the weakest adjacent rival with hysteresis, funneling interior supply to a single sortie front

- **Renderer enhancements** (`src/render/Renderer.js`):
  - Added `showOverlay` toggle to visualize painter plans
  - New `drawStrategyOverlay()` method that renders:
    - Shield marks on SINK tiles (hold positions)
    - Directional chevrons on SORTIE tiles (attack fronts)
    - Faint flow ticks on interior tiles near the front (supply direction)

- **UI updates** (`src/ui/Controls.js`, `index.html`):
  - Added toggle control for strategy overlay visualization

- **Strategy registry** (`src/strategies/index.js`):
  - Registered three new strategies

## Implementation Details

- Plans are cached on the `game` object keyed by player ID and tick, so only the first army of a player to act pays the painter cost
- Tile ownership determined by first registered army (matches `recomputeTerritory` logic)
- BFS depth computed from seed tiles (fronts or sorties) to guide interior flow
- Wrapping maps handled correctly in distance calculations
- CitadelSortie includes hysteresis to prevent flickering target selection across ticks

https://claude.ai/code/session_01A8FRSvGLpr9SekYMXeGPyM