### PR TITLE
Refactor map form to auto-apply changes and support fixed lineups

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
             <label>Players<input id="me-players" type="number" min="2" max="8" value="4" /></label>
             <label class="me-check"><input id="me-wrap" type="checkbox" checked />Wrap</label>
           </div>
-          <button id="btn-me-apply" class="btn primary">Apply</button>
         </div>
       </div>
 

--- a/src/main.js
+++ b/src/main.js
@@ -66,11 +66,11 @@ class App {
       app: this,
     });
     this.mapEditor = new MapEditor({ app: this });
-    // Initial match: load the default Custom Map fields with random bots
-    // from STRATEGY_LIST so the canvas isn't blank before rankings load.
+    // Initial match: seed the canvas with default form values + top of
+    // STRATEGY_LIST so something renders before rankings.json loads.
     this.loadCustomMap(this.mapEditor.read());
     // Reset the override flag so the rankings loader can replace the
-    // initial canvas with a top-tier match if rankings.json exists.
+    // initial canvas with a top-tier match once rankings.json arrives.
     this._userChoseMode = false;
     this.leagueViewer = new LeagueViewer({
       root: document.getElementById("league-viewer"),
@@ -83,6 +83,19 @@ class App {
       },
     });
     this.startLoop();
+  }
+
+  // Called by MapEditor whenever a form field or preset changes. Re-runs
+  // the match through the rankings flow when a selection is available;
+  // falls back to the default-strategies path when rankings haven't
+  // loaded (or when the selection has been emptied).
+  applyMapForm() {
+    this._userChoseMode = true;
+    if (this.leagueViewer?.canWatch()) {
+      this.leagueViewer.watchMatch();
+    } else {
+      this.loadCustomMap(this.mapEditor.read());
+    }
   }
 
   loadReplay(entry) {
@@ -159,24 +172,30 @@ class App {
     this.markDirty();
   }
 
-  loadCustomMap({ width, height, growth, maxArmy, wrap, numPlayers, botNames = null }) {
+  loadCustomMap({ width, height, growth, maxArmy, wrap, numPlayers, botNames = null, fixedLineup = false }) {
     // Transient ad-hoc map: build a Game with the user's config and seat
-    // N bots in a ring. If `botNames` is given, sample numPlayers from
-    // that pool (random — this is a UI affordance, not a deterministic
-    // tournament match); otherwise default to the top of STRATEGY_LIST.
+    // N bots in a ring. If `botNames` is given:
+    //   - fixedLineup=true: use the names in order (Reset path).
+    //   - otherwise: sample numPlayers random names from the pool.
+    // No botNames → top of STRATEGY_LIST.
     let strategies;
     if (botNames) {
-      const pool = botNames
-        .map((n) => ALL_STRATEGIES[n])
-        .filter(Boolean);
-      if (pool.length < numPlayers) {
-        throw new Error(`Pool has ${pool.length} valid bots; need ${numPlayers}`);
-      }
-      strategies = [];
-      const remaining = pool.slice();
-      for (let i = 0; i < numPlayers; i++) {
-        const j = Math.floor(Math.random() * remaining.length);
-        strategies.push(remaining.splice(j, 1)[0]);
+      const pool = botNames.map((n) => ALL_STRATEGIES[n]).filter(Boolean);
+      if (fixedLineup) {
+        if (pool.length < numPlayers) {
+          throw new Error(`Saved lineup has ${pool.length} valid bots; need ${numPlayers}`);
+        }
+        strategies = pool.slice(0, numPlayers);
+      } else {
+        if (pool.length < numPlayers) {
+          throw new Error(`Pool has ${pool.length} valid bots; need ${numPlayers}`);
+        }
+        strategies = [];
+        const remaining = pool.slice();
+        for (let i = 0; i < numPlayers; i++) {
+          const j = Math.floor(Math.random() * remaining.length);
+          strategies.push(remaining.splice(j, 1)[0]);
+        }
       }
     } else {
       strategies = STRATEGY_LIST.slice(0, numPlayers);
@@ -190,7 +209,13 @@ class App {
     this.autoStopOnWinner = false;
     this.modeKey = "custom";
     this.mode = { key: "custom", name: "Custom Map" };
-    this.lastCustomArgs = { width, height, growth, maxArmy, wrap, numPlayers };
+    // Snapshot the chosen lineup so Reset reproduces the same matchup
+    // (different seed, same bots & map config).
+    this.lastCustomArgs = {
+      width, height, growth, maxArmy, wrap, numPlayers,
+      botNames: strategies.map((s) => s.name),
+      fixedLineup: true,
+    };
     this.game = new Game({ width, height, growth, maxArmy, wrap, seed });
 
     const cx = width / 2;

--- a/src/ui/LeagueViewer.js
+++ b/src/ui/LeagueViewer.js
@@ -6,11 +6,12 @@
 //   - Click a row to toggle it in/out of the selection.
 //   - Tier shortcut buttons (T1, T2, …) replace the selection with a
 //     band of the ranking (T1 = ranks 1-10, T2 = 11-20, etc.).
-//   - "Watch random match" reads the Custom Map sidebar fields, samples
+//   - "Watch random match" reads the Map sidebar fields, samples
 //     numPlayers bots from the current selection, and asks the app to
-//     load that match. Map config and player count come from the Custom
-//     Map form — the rankings list only owns "which bots are in the
-//     pool."
+//     load that match. Map config and player count come from the Map
+//     form — the rankings list only owns "which bots are in the pool."
+//   - Any change to the Map form auto-reloads through this same path
+//     (see App.applyMapForm).
 //
 // If tournament/rankings.json is missing, we show a hint to run
 // `npm run tournament -- --league` to generate it.
@@ -74,13 +75,8 @@ export class LeagueViewer {
     this.render();
   }
 
-  // Suggested first match args for the auto-loader on first load. Picks
-  // numPlayers random bots from the top tier — the most intuitive default.
-  topTierArgs(numPlayers = 4) {
-    if (!this.rankings) return null;
-    const pool = this.rankings.players.slice(0, TIER_SIZE).map((p) => p.name);
-    if (pool.length < numPlayers) return null;
-    return { botNames: pool, numPlayers };
+  canWatch() {
+    return !!this.rankings && this.selection.size >= 2;
   }
 
   render() {
@@ -168,41 +164,13 @@ export class LeagueViewer {
   }
 
   watchMatch() {
-    const cfg = readMapEditor();
+    const cfg = this.app.mapEditor.read();
     const pool = [...this.selection];
     if (pool.length < 2) return;
     const numPlayers = Math.min(cfg.numPlayers, pool.length);
     this.app._userChoseMode = true;
     this.app.loadCustomMap({ ...cfg, numPlayers, botNames: pool });
   }
-}
-
-function readMapEditor() {
-  const w = document.getElementById("me-width");
-  const h = document.getElementById("me-height");
-  const g = document.getElementById("me-growth");
-  const m = document.getElementById("me-max-army");
-  const p = document.getElementById("me-players");
-  const wr = document.getElementById("me-wrap");
-  return {
-    width: clampInt(w?.value, 6, 120, 30),
-    height: clampInt(h?.value, 6, 120, 22),
-    growth: clampFloat(g?.value, 0.1, 5, 1.8),
-    maxArmy: clampInt(m?.value, 1, 20, 6),
-    numPlayers: clampInt(p?.value, 2, 8, 4),
-    wrap: !!wr?.checked,
-  };
-}
-
-function clampInt(raw, lo, hi, fallback) {
-  const n = parseInt(raw, 10);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.max(lo, Math.min(hi, n));
-}
-function clampFloat(raw, lo, hi, fallback) {
-  const n = parseFloat(raw);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.max(lo, Math.min(hi, n));
 }
 
 function escapeHtml(s) {

--- a/src/ui/MapEditor.js
+++ b/src/ui/MapEditor.js
@@ -1,13 +1,17 @@
-// Sidebar form for spinning up a match. Reads width / height / growth /
-// maxArmy / wrap / numPlayers from inputs and asks the app to build a
-// Game with that config plus N ring-positioned bots.
+// Sidebar form for the map config used by "Watch random match". Owns
+// width / height / growth / maxArmy / wrap / numPlayers inputs plus the
+// preset tabs (arena, classic, lab1, ...). Any change re-runs the
+// current scenario through `app.applyMapForm()`; the rankings panel
+// supplies the bot pool.
 //
-// Map presets (arena, classic, lab1, ...) are rendered as quick-fill
-// buttons that populate the form fields and submit. They share the
-// preset registry with the headless tournament runner so a preset
-// always means the same configuration in both contexts.
+// Map presets share their config with the headless tournament runner
+// so a preset always means the same map shape in both contexts. Each
+// preset also carries a recommended player count, which fills the
+// Players field when the preset is clicked (still editable).
 
 import { MAPS } from "../../tournament/maps.js";
+
+const DEFAULT_PRESET_PLAYERS = 4;
 
 export class MapEditor {
   constructor({ app }) {
@@ -18,10 +22,12 @@ export class MapEditor {
     this.maxArmy = document.getElementById("me-max-army");
     this.players = document.getElementById("me-players");
     this.wrap = document.getElementById("me-wrap");
-    this.apply = document.getElementById("btn-me-apply");
     this.presets = document.getElementById("me-presets");
 
-    this.apply.addEventListener("click", () => this.submit());
+    const inputs = [this.width, this.height, this.growth, this.maxArmy, this.players, this.wrap];
+    for (const el of inputs) {
+      el.addEventListener("change", () => this.app.applyMapForm());
+    }
     this.renderPresets();
   }
 
@@ -33,21 +39,22 @@ export class MapEditor {
       btn.className = "preset-tab";
       btn.textContent = key;
       const c = preset.config;
-      btn.title = `${c.width}×${c.height} · g=${c.growth} · maxArmy=${c.maxArmy}${c.wrap ? " · wrap" : ""}`;
-      btn.addEventListener("click", () => this.applyPreset(preset.config));
+      const k = preset.players ?? DEFAULT_PRESET_PLAYERS;
+      btn.title = `${c.width}×${c.height} · g=${c.growth} · maxArmy=${c.maxArmy}${c.wrap ? " · wrap" : ""} · ${k} players`;
+      btn.addEventListener("click", () => this.applyPreset(preset));
       this.presets.appendChild(btn);
     }
   }
 
-  applyPreset(config) {
-    this.width.value = config.width;
-    this.height.value = config.height;
-    this.growth.value = config.growth;
-    this.maxArmy.value = config.maxArmy;
-    this.wrap.checked = !!config.wrap;
-    // numPlayers stays — the preset only owns the map shape, not the
-    // roster size. Submit immediately so the user sees the new map.
-    this.submit();
+  applyPreset(preset) {
+    const c = preset.config;
+    this.width.value = c.width;
+    this.height.value = c.height;
+    this.growth.value = c.growth;
+    this.maxArmy.value = c.maxArmy;
+    this.wrap.checked = !!c.wrap;
+    this.players.value = preset.players ?? DEFAULT_PRESET_PLAYERS;
+    this.app.applyMapForm();
   }
 
   read() {
@@ -59,11 +66,6 @@ export class MapEditor {
       numPlayers: clampInt(this.players.value, 2, 8, 4),
       wrap: !!this.wrap.checked,
     };
-  }
-
-  submit() {
-    this.app._userChoseMode = true;
-    this.app.loadCustomMap(this.read());
   }
 }
 

--- a/tournament/maps.js
+++ b/tournament/maps.js
@@ -77,34 +77,40 @@ export const MAPS = {
   arena: {
     name: "arena",
     config: { width: 30, height: 22, growth: 2, maxArmy: 6, wrap: true },
+    players: 4,
     positions: (n) => ringPositions(n, { width: 30, height: 22, radiusFactor: 0.4 }),
   },
   classic: {
     name: "classic",
     config: { width: 40, height: 30, growth: 1, maxArmy: 6, wrap: true },
+    players: 6,
     positions: (n) => ringPositions(n, { width: 40, height: 30, radiusFactor: 0.42 }),
   },
   tight: {
     name: "tight",
     config: { width: 22, height: 16, growth: 2.2, maxArmy: 6, wrap: true },
+    players: 3,
     positions: (n) => ringPositions(n, { width: 22, height: 16, radiusFactor: 0.38 }),
   },
   // Lab-tested map (24x18 g=1.8 wrap line k=4). Composite score from map-search ranking, disc=0.74 rel=0.87.
   lab1: {
     name: "lab1",
     config: { width: 24, height: 18, growth: 1.8, maxArmy: 6, wrap: true },
+    players: 4,
     positions: (n) => linePositions(n, { width: 24, height: 18 }),
   },
   // Lab-tested map (30x22 g=1.8 wrap line k=4). Composite score from map-search ranking, disc=0.79 rel=0.89.
   lab2: {
     name: "lab2",
     config: { width: 30, height: 22, growth: 1.8, maxArmy: 6, wrap: true },
+    players: 4,
     positions: (n) => linePositions(n, { width: 30, height: 22 }),
   },
   // Lab-tested map (38x28 g=1.8 wrap line k=4). Composite score from map-search ranking, disc=0.73 rel=0.90.
   lab3: {
     name: "lab3",
     config: { width: 38, height: 28, growth: 1.8, maxArmy: 6, wrap: true },
+    players: 4,
     positions: (n) => linePositions(n, { width: 38, height: 28 }),
   },
 };


### PR DESCRIPTION
## Summary
This PR refactors the map configuration form to automatically apply changes instead of requiring an explicit "Apply" button, and adds support for fixed bot lineups when replaying saved matches.

## Key Changes

- **Auto-apply map form changes**: Removed the "Apply" button and replaced it with `change` event listeners on all form inputs. Any modification to width, height, growth, maxArmy, players, or wrap now immediately triggers `app.applyMapForm()`.

- **New `applyMapForm()` method**: Centralized logic that either watches a ranked match (if rankings are available and a selection exists) or loads a custom map with default strategies.

- **Fixed lineup support**: Added `fixedLineup` parameter to `loadCustomMap()` to distinguish between:
  - Random sampling from a bot pool (UI mode, `fixedLineup=false`)
  - Using bots in order (Reset/replay mode, `fixedLineup=true`)

- **Preset player counts**: Map presets now carry a recommended player count (`players` field) that auto-fills the Players input when a preset is clicked, while remaining editable.

- **Snapshot bot lineups**: When a custom match is created, `lastCustomArgs` now captures the actual bot names and `fixedLineup=true`, ensuring Reset reproduces the exact same matchup with a different seed.

- **Simplified LeagueViewer**: Removed `topTierArgs()` and `readMapEditor()` helper functions. LeagueViewer now calls `app.mapEditor.read()` directly and uses a new `canWatch()` method to check if a ranked match can be loaded.

- **Updated documentation**: Clarified comments throughout to reflect that the map form is now the "Map sidebar" (not "Custom Map sidebar") and that it's used by the "Watch random match" feature.

## Implementation Details

- The form now uses event delegation via `change` listeners instead of a submit button, making the UI more responsive.
- Preset tabs now display the recommended player count in their tooltip.
- The `fixedLineup` flag ensures that saved replays use the exact bot order, while interactive play samples randomly from the pool.

https://claude.ai/code/session_01EG2dMynxuWus8ayxos1PDG