### PR TITLE
Surface match seeds and add browser-side save/replay UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,9 @@
       <span class="kbd">Space</span><span class="brand-sub">play</span>
       <span class="kbd">.</span><span class="brand-sub">step</span>
       <span class="kbd">R</span><span class="brand-sub">reset</span>
+      <span class="kbd">L</span><span class="brand-sub">replay</span>
+      <span class="kbd">S</span><span class="brand-sub">save</span>
+      <span id="seed-pill" class="seed-pill" title="Click to copy">seed=–</span>
     </header>
 
     <aside class="sidebar">
@@ -26,7 +29,9 @@
         <div class="controls">
           <button id="btn-play" class="btn primary">⏸ Pause</button>
           <button id="btn-step" class="btn">⏭ Step</button>
-          <button id="btn-reset" class="btn">↻ Reset</button>
+          <button id="btn-reset" class="btn" title="New seed, same lineup &amp; map">↻ New seed</button>
+          <button id="btn-replay" class="btn" title="Replay same seed">↺ Replay</button>
+          <button id="btn-save" class="btn" title="Save this seed to your local list">★ Save</button>
         </div>
         <div class="slider-row" style="margin-top:10px;">
           <span class="brand-sub">Speed</span>

--- a/src/main.js
+++ b/src/main.js
@@ -40,11 +40,11 @@ class App {
     this.engine.on("snapshot", () => this.markDirty());
     this.engine.on("players:changed", () => this.markDirty());
     this.engine.on("winner", ({ name }) => {
-      this.controls.log(`👑 ${name} wins!`);
+      this.controls.log(`👑 ${name} wins!`, this._snapshotMatchInfo());
       if (this.autoStopOnWinner && this.playing) this._setPlayingLocal(false);
     });
     this.engine.on("draw", () => {
-      this.controls.log(`💀 Mutual destruction.`);
+      this.controls.log(`💀 Mutual destruction.`, this._snapshotMatchInfo());
       if (this.autoStopOnWinner && this.playing) this._setPlayingLocal(false);
     });
 
@@ -113,6 +113,16 @@ class App {
     this.autoStopOnWinner = true;
     this.modeKey = "replay";
     this.mode = { key: "replay", name: `Replay #${entry.id}` };
+    this.currentMatch = {
+      kind: "replay",
+      id: entry.id,
+      map: entry.map,
+      mapConfig: entry.mapConfig,
+      seed: entry.seed,
+      lineup: entry.lineup,
+      lineupTech: entry.lineupTech ?? null,
+      startPositions: entry.startPositions,
+    };
 
     this.engine.loadReplay({
       mapConfig: entry.mapConfig,
@@ -132,12 +142,13 @@ class App {
     this.activePlayer = this.game.players.list[0] ?? null;
     this.matchPicker?.setActive(entry.id);
     this.controls.log(`▶ Replay #${entry.id} · ${entry.lineup.join(", ")}`);
+    this.controls.updateMatchInfo(this.currentMatch);
     this.bindCanvas();
     this._setPlayingLocal(true);
     this.markDirty();
   }
 
-  loadCustomMap({ width, height, growth, maxArmy, wrap, numPlayers, botNames = null, fixedLineup = false }) {
+  loadCustomMap({ width, height, growth, maxArmy, wrap, numPlayers, botNames = null, fixedLineup = false, seed = null, startPositions = null }) {
     // Transient ad-hoc map: build a Game with the user's config and seat
     // N bots in a ring. If `botNames` is given:
     //   - fixedLineup=true: use the names in order (Reset path).
@@ -168,7 +179,7 @@ class App {
         throw new Error(`Not enough strategies for ${numPlayers} players`);
       }
     }
-    const seed = (Date.now() & 0x7fffffff) >>> 0;
+    const useSeed = seed != null ? (seed >>> 0) : ((Date.now() & 0x7fffffff) >>> 0);
 
     this.replayEntry = null;
     this.autoStopOnWinner = false;
@@ -182,36 +193,115 @@ class App {
       fixedLineup: true,
     };
 
-    const cx = width / 2;
-    const cy = height / 2;
-    const r = Math.min(width, height) * 0.4;
-    const startPositions = [];
-    for (let i = 0; i < numPlayers; i++) {
-      const angle = (i / numPlayers) * Math.PI * 2;
-      const x = Math.max(1, Math.min(width - 2, Math.floor(cx + Math.cos(angle) * r)));
-      const y = Math.max(1, Math.min(height - 2, Math.floor(cy + Math.sin(angle) * r)));
-      startPositions.push({ x, y });
+    let positions = startPositions;
+    if (!positions) {
+      const cx = width / 2;
+      const cy = height / 2;
+      const r = Math.min(width, height) * 0.4;
+      positions = [];
+      for (let i = 0; i < numPlayers; i++) {
+        const angle = (i / numPlayers) * Math.PI * 2;
+        const x = Math.max(1, Math.min(width - 2, Math.floor(cx + Math.cos(angle) * r)));
+        const y = Math.max(1, Math.min(height - 2, Math.floor(cy + Math.sin(angle) * r)));
+        positions.push({ x, y });
+      }
     }
+
+    this.currentMatch = {
+      kind: "custom",
+      id: null,
+      map: "custom",
+      mapConfig: { width, height, growth, maxArmy, wrap },
+      seed: useSeed,
+      lineup: strategies.map((s) => s.name),
+      lineupTech: null,
+      startPositions: positions,
+    };
 
     this.engine.loadCustom({
       mapConfig: { width, height, growth, maxArmy, wrap },
       lineupStrategies: strategies,
-      startPositions,
-      seed,
+      startPositions: positions,
+      seed: useSeed,
     });
     this.renderer.resize();
     this.chart.resize();
     this.territoryChart.resize();
 
     document.getElementById("mode-description").textContent =
-      `Custom · ${width}×${height} · g=${growth} · maxArmy=${maxArmy}${wrap ? " · wrap" : ""} · ${numPlayers} bots`;
+      `Custom · ${width}×${height} · g=${growth} · maxArmy=${maxArmy}${wrap ? " · wrap" : ""} · ${numPlayers} bots · seed=${useSeed}`;
 
     this.activePlayer = this.game.players.list[0] ?? null;
     this.matchPicker?.setActive(null);
-    this.controls.log(`🛠 Custom map · ${width}×${height} · ${numPlayers} bots`);
+    this.controls.log(`🛠 Custom map · ${width}×${height} · ${numPlayers} bots · seed=${useSeed}`);
+    this.controls.updateMatchInfo(this.currentMatch);
     this.bindCanvas();
     this._setPlayingLocal(true);
     this.markDirty();
+  }
+
+  // Snapshot the current match in a form ready for `loadFromMatchInfo` or
+  // `saveCurrentMatch`. Returns null if no match has been loaded yet.
+  _snapshotMatchInfo() {
+    return this.currentMatch ? { ...this.currentMatch } : null;
+  }
+
+  // Re-run the match described by `info`. Used by the event log click
+  // handler to replay any past winner/draw line, and by the saved-match
+  // panel for browser-side stored entries.
+  loadFromMatchInfo(info) {
+    if (!info) return;
+    this._userChoseMode = true;
+    if (info.kind === "replay" || info.id != null) {
+      this.loadReplay({
+        id: info.id,
+        map: info.map,
+        mapConfig: info.mapConfig,
+        seed: info.seed,
+        lineup: info.lineup,
+        lineupTech: info.lineupTech ?? null,
+        startPositions: info.startPositions,
+        flags: info.flags ?? [],
+      });
+      return;
+    }
+    const cfg = info.mapConfig;
+    this.loadCustomMap({
+      width: cfg.width,
+      height: cfg.height,
+      growth: cfg.growth,
+      maxArmy: cfg.maxArmy,
+      wrap: !!cfg.wrap,
+      numPlayers: info.lineup.length,
+      botNames: info.lineup,
+      fixedLineup: true,
+      seed: info.seed,
+      startPositions: info.startPositions,
+    });
+  }
+
+  // Re-run with the same seed as the current match. Pairs with
+  // `reload()` (Reset = new seed).
+  replaySameSeed() {
+    if (!this.currentMatch) {
+      this.reload();
+      return;
+    }
+    this.loadFromMatchInfo(this.currentMatch);
+  }
+
+  // Persist the current match to localStorage so it shows up alongside
+  // the static tournament/interesting.json picks.
+  saveCurrentMatch() {
+    if (!this.currentMatch) {
+      this.controls.log("⚠ Nothing to save yet.");
+      return null;
+    }
+    const saved = this.matchPicker?.saveLocal(this.currentMatch) ?? null;
+    if (saved) {
+      this.controls.log(`★ Saved seed=${saved.seed} as ${saved.id}`);
+    }
+    return saved;
   }
 
   bindCanvas() {

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -9,6 +9,8 @@ export class Controls {
     this.btnPlay = $("#btn-play");
     this.btnStep = $("#btn-step");
     this.btnReset = $("#btn-reset");
+    this.btnReplay = $("#btn-replay");
+    this.btnSave = $("#btn-save");
     this.speed = $("#speed");
     this.speedLabel = $("#speed-label");
     this.toggleGrid = $("#toggle-grid");
@@ -17,11 +19,15 @@ export class Controls {
     this.toggleMoves = $("#toggle-moves");
     this.toggleOverlay = $("#toggle-overlay");
     this.tickLabel = $("#tick-label");
+    this.seedPill = $("#seed-pill");
     this.eventLog = $("#event-log");
 
     this.btnPlay.addEventListener("click", () => this.app.togglePlay());
     this.btnStep.addEventListener("click", () => this.app.stepOnce());
     this.btnReset.addEventListener("click", () => this.app.reload());
+    this.btnReplay?.addEventListener("click", () => this.app.replaySameSeed());
+    this.btnSave?.addEventListener("click", () => this.app.saveCurrentMatch());
+    this.seedPill?.addEventListener("click", () => this._copySeed());
     this.speed.addEventListener("input", () => {
       const v = parseFloat(this.speed.value);
       this.app.setSpeed(v);
@@ -54,6 +60,10 @@ export class Controls {
         this.app.togglePlay();
       } else if (e.key === "r" || e.key === "R") {
         this.app.reload();
+      } else if (e.key === "l" || e.key === "L") {
+        this.app.replaySameSeed();
+      } else if (e.key === "s" || e.key === "S") {
+        this.app.saveCurrentMatch();
       } else if (e.key === ".") {
         this.app.stepOnce();
       }
@@ -68,14 +78,50 @@ export class Controls {
     this.tickLabel.textContent = `t=${t}`;
   }
 
-  log(message) {
+  // Mirror the active match's seed in the header pill so users can see
+  // it without scanning the mode-description line.
+  updateMatchInfo(info) {
+    if (!this.seedPill) return;
+    if (!info || info.seed == null) {
+      this.seedPill.textContent = "seed=–";
+      this.seedPill.title = "No active match";
+    } else {
+      this.seedPill.textContent = `seed=${info.seed}`;
+      this.seedPill.title = `Click to copy ${info.seed}`;
+    }
+  }
+
+  // Append a log line. When `replayInfo` is supplied the line becomes a
+  // clickable replay shortcut — clicking it re-runs that exact match.
+  log(message, replayInfo = null) {
     if (!this.eventLog) return;
     const entry = document.createElement("div");
     entry.className = "log-entry";
-    entry.textContent = message;
+    if (replayInfo && replayInfo.seed != null) {
+      entry.classList.add("log-replay");
+      entry.title = `Click to replay (seed=${replayInfo.seed})`;
+      entry.textContent = `${message}  ↺`;
+      entry.addEventListener("click", () => {
+        this.app.loadFromMatchInfo(replayInfo);
+      });
+    } else {
+      entry.textContent = message;
+    }
     this.eventLog.prepend(entry);
     while (this.eventLog.children.length > 30) {
       this.eventLog.removeChild(this.eventLog.lastChild);
+    }
+  }
+
+  async _copySeed() {
+    const info = this.app.currentMatch;
+    if (!info || info.seed == null) return;
+    try {
+      await navigator.clipboard.writeText(String(info.seed));
+      this.log(`📋 Copied seed=${info.seed}`);
+    } catch {
+      // Silently ignore clipboard rejection (older browsers, insecure
+      // origin, etc.) — the seed is also visible in mode-description.
     }
   }
 }

--- a/src/ui/LeagueViewer.js
+++ b/src/ui/LeagueViewer.js
@@ -3,15 +3,18 @@
 //
 // Design:
 //   - Single global ranked list of every bot, top to bottom by rating.
-//   - Click a row to toggle it in/out of the selection.
-//   - Tier shortcut buttons (T1, T2, …) replace the selection with a
-//     band of the ranking (T1 = ranks 1-10, T2 = 11-20, etc.).
+//   - Click a row to toggle it. Shift-click extends a range from the
+//     last clicked row; Ctrl/Cmd-click toggles a single row without
+//     touching the rest (same as plain click — kept for muscle memory).
+//   - Tier shortcut buttons (T1, T2, …): plain click replaces the
+//     selection with that tier. Shift-click extends the selection across
+//     a range of tiers (anchored on the last clicked tier). Ctrl/Cmd-
+//     click toggles just that tier in/out of the current selection.
 //   - "Watch random match" reads the Map sidebar fields, samples
 //     numPlayers bots from the current selection, and asks the app to
-//     load that match. Map config and player count come from the Map
-//     form — the rankings list only owns "which bots are in the pool."
-//   - Any change to the Map form auto-reloads through this same path
-//     (see App.applyMapForm).
+//     load that match.
+//   - Selection toggles update only the affected rows in place so the
+//     ranking-list scroll position is preserved across clicks.
 //
 // If tournament/rankings.json is missing, we show a hint to run
 // `npm run tournament -- --league` to generate it.
@@ -27,6 +30,12 @@ export class LeagueViewer {
     this.selection = new Set();
     this._onFirstLoad = onFirstLoad;
     this._firstLoadDone = false;
+    this._lastTierClicked = null;
+    this._lastBotIndex = null;
+    this._listEl = null;
+    this._tabsEl = null;
+    this._sumEl = null;
+    this._watchBtn = null;
 
     refreshButton?.addEventListener("click", () => this.load());
     this.load();
@@ -50,7 +59,6 @@ export class LeagueViewer {
       return;
     }
     this.rankings = parsed;
-    // Default selection: top tier-size bots.
     if (this.selection.size === 0) this.applyTier(0);
     this.render();
     this._notifyFirstLoad();
@@ -69,10 +77,57 @@ export class LeagueViewer {
     this.selection = new Set(slice.map((p) => p.name));
   }
 
-  toggle(name) {
-    if (this.selection.has(name)) this.selection.delete(name);
-    else this.selection.add(name);
-    this.render();
+  // Modifier-aware tier handler:
+  //   plain → replace selection with this tier
+  //   shift → extend across [_lastTierClicked, t] tier band
+  //   ctrl/meta → toggle just this tier in/out of selection
+  handleTierClick(t, e) {
+    const players = this.rankings?.players ?? [];
+    const sliceFor = (idx) => players.slice(idx * TIER_SIZE, idx * TIER_SIZE + TIER_SIZE);
+    if (e?.shiftKey && this._lastTierClicked != null) {
+      const a = Math.min(this._lastTierClicked, t);
+      const b = Math.max(this._lastTierClicked, t);
+      const next = new Set(this.selection);
+      for (let i = a; i <= b; i++) {
+        for (const p of sliceFor(i)) next.add(p.name);
+      }
+      this.selection = next;
+    } else if (e?.ctrlKey || e?.metaKey) {
+      const slice = sliceFor(t);
+      const allIn = slice.every((p) => this.selection.has(p.name));
+      const next = new Set(this.selection);
+      for (const p of slice) {
+        if (allIn) next.delete(p.name);
+        else next.add(p.name);
+      }
+      this.selection = next;
+    } else {
+      this.applyTier(t);
+    }
+    this._lastTierClicked = t;
+    this._refreshSelectionUi();
+  }
+
+  // Modifier-aware row handler:
+  //   plain → toggle this row only
+  //   shift → set every row in [_lastBotIndex, idx] to selected
+  //   ctrl/meta → toggle this row only (same as plain; explicit for parity)
+  handleRowClick(idx, name, e) {
+    const players = this.rankings?.players ?? [];
+    if (e?.shiftKey && this._lastBotIndex != null) {
+      const a = Math.min(this._lastBotIndex, idx);
+      const b = Math.max(this._lastBotIndex, idx);
+      const next = new Set(this.selection);
+      for (let i = a; i <= b; i++) {
+        if (players[i]) next.add(players[i].name);
+      }
+      this.selection = next;
+    } else {
+      if (this.selection.has(name)) this.selection.delete(name);
+      else this.selection.add(name);
+    }
+    this._lastBotIndex = idx;
+    this._refreshSelectionUi();
   }
 
   canWatch() {
@@ -99,42 +154,37 @@ export class LeagueViewer {
     `;
     wrap.appendChild(head);
 
-    // Tier-band buttons: T1, T2, … each click replaces selection.
     const tierCount = Math.ceil(r.players.length / TIER_SIZE);
     const tabs = document.createElement("div");
     tabs.className = "tier-tabs";
+    tabs.title = "Click: replace · Shift-click: extend · Ctrl/⌘-click: toggle";
     for (let t = 0; t < tierCount; t++) {
       const btn = document.createElement("button");
       btn.className = "tier-tab";
+      btn.dataset.tier = t;
       btn.textContent = `T${t + 1}`;
       const start = t * TIER_SIZE;
       const slice = r.players.slice(start, start + TIER_SIZE);
-      // "Active" = the current selection equals this tier exactly.
-      const sliceNames = new Set(slice.map((p) => p.name));
-      const matches = sliceNames.size === this.selection.size &&
-        [...sliceNames].every((n) => this.selection.has(n));
-      if (matches) btn.classList.add("active");
-      btn.title = `Select ranks ${start + 1}–${start + slice.length}: ${slice.slice(0, 3).map((p) => p.name).join(", ")}…`;
-      btn.addEventListener("click", () => {
-        this.applyTier(t);
-        this.render();
-      });
+      btn.title = `Ranks ${start + 1}–${start + slice.length}: ${slice.slice(0, 3).map((p) => p.name).join(", ")}…`;
+      btn.addEventListener("click", (e) => this.handleTierClick(t, e));
       tabs.appendChild(btn);
     }
     wrap.appendChild(tabs);
+    this._tabsEl = tabs;
 
-    // Selection summary line.
     const sumLine = document.createElement("div");
     sumLine.className = "league-selection-sum";
     sumLine.textContent = `${this.selection.size} selected`;
     wrap.appendChild(sumLine);
+    this._sumEl = sumLine;
 
-    // Single ranked list of all bots.
     const list = document.createElement("div");
     list.className = "ranking-list";
     r.players.forEach((p, i) => {
       const row = document.createElement("button");
       row.className = "ranking-row";
+      row.dataset.name = p.name;
+      row.dataset.idx = i;
       const selected = this.selection.has(p.name);
       if (selected) row.classList.add("selected");
       row.innerHTML = `
@@ -143,24 +193,57 @@ export class LeagueViewer {
         <span class="rr-name">${escapeHtml(p.name)}</span>
         <span class="rr-rating">${p.rating}</span>
       `;
-      row.title = `${p.matches} matches · ${p.wins} wins · avgFinish=${p.avgFinish ?? "-"}`;
-      row.addEventListener("click", () => this.toggle(p.name));
+      row.title = `${p.matches} matches · ${p.wins} wins · avgFinish=${p.avgFinish ?? "-"}\nClick: toggle · Shift-click: range`;
+      row.addEventListener("click", (e) => this.handleRowClick(i, p.name, e));
       list.appendChild(row);
     });
     wrap.appendChild(list);
+    this._listEl = list;
 
-    // Watch button.
     const btn = document.createElement("button");
     btn.className = "btn btn-watch";
     btn.textContent = `▶ Watch random match`;
     btn.addEventListener("click", () => this.watchMatch());
-    if (this.selection.size < 2) {
-      btn.disabled = true;
-      btn.title = "Select at least 2 bots";
-    }
     wrap.appendChild(btn);
+    this._watchBtn = btn;
 
+    this._refreshSelectionUi();
     return wrap;
+  }
+
+  // Update only the bits of UI affected by a selection change:
+  //   - tier-tab active flags
+  //   - selection-count line
+  //   - per-row .selected class + ● / ○ glyph
+  //   - watch-button enabled state
+  // Crucially, we do NOT replace .ranking-list children, so its scroll
+  // position (and the user's place in the list) is preserved.
+  _refreshSelectionUi() {
+    if (this._tabsEl && this.rankings) {
+      const players = this.rankings.players;
+      for (const tab of this._tabsEl.querySelectorAll(".tier-tab")) {
+        const t = Number(tab.dataset.tier);
+        const slice = players.slice(t * TIER_SIZE, t * TIER_SIZE + TIER_SIZE);
+        const allIn = slice.length > 0 && slice.every((p) => this.selection.has(p.name));
+        tab.classList.toggle("active", allIn);
+      }
+    }
+    if (this._sumEl) {
+      this._sumEl.textContent = `${this.selection.size} selected`;
+    }
+    if (this._listEl) {
+      for (const row of this._listEl.querySelectorAll(".ranking-row")) {
+        const sel = this.selection.has(row.dataset.name);
+        row.classList.toggle("selected", sel);
+        const mark = row.querySelector(".rr-mark");
+        if (mark) mark.textContent = sel ? "●" : "○";
+      }
+    }
+    if (this._watchBtn) {
+      const enable = this.selection.size >= 2;
+      this._watchBtn.disabled = !enable;
+      this._watchBtn.title = enable ? "" : "Select at least 2 bots";
+    }
   }
 
   watchMatch() {

--- a/src/ui/MatchPicker.js
+++ b/src/ui/MatchPicker.js
@@ -1,36 +1,38 @@
-// Sidebar widget that fetches tournament/interesting.json and renders a
-// clickable list of saved matches. Click → app.loadReplay(entry).
+// Sidebar widget that lists saved matches: ones served from
+// tournament/interesting.json (the headless-tournament picks) merged with
+// browser-saved entries kept in localStorage. Click → app.loadReplay(entry).
 //
-// The JSON is the same file the headless tournament writes via
-// tournament/store.js. When a future browser-side tournament runner lands,
-// it will write to localStorage with the same shape and we'll add a switch
-// here to merge both sources.
+// Browser-saved entries carry string ids (`local-<n>`) so they don't
+// collide with the integer ids the headless tournament writes. They can
+// be deleted from the UI; server-side entries are read-only here.
 
 const STORE_URL = "tournament/interesting.json";
+const LS_KEY = "pixelwars.savedMatches.v1";
 
 export class MatchPicker {
   constructor({ root, refreshButton, app }) {
     this.root = root;
     this.app = app;
-    this.entries = [];
+    this.serverEntries = [];
+    this.localEntries = [];
     this.activeId = null;
 
     refreshButton?.addEventListener("click", () => this.load());
+    this.localEntries = this._readLocal();
     this.load();
   }
 
   async load() {
     this.root.innerHTML = `<div class="hud-empty">Loading…</div>`;
     try {
-      // Cache-bust so the browser sees fresh tournament writes without a hard reload.
       const res = await fetch(`${STORE_URL}?t=${Date.now()}`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const parsed = await res.json();
-      this.entries = Array.isArray(parsed?.entries) ? parsed.entries : [];
+      this.serverEntries = Array.isArray(parsed?.entries) ? parsed.entries : [];
     } catch (e) {
-      this.root.innerHTML = `<div class="hud-empty">No saved matches.<br/><span style="font-size:10px">Run a tournament: <code>node tournament/run.js</code></span></div>`;
-      return;
+      this.serverEntries = [];
     }
+    this.localEntries = this._readLocal();
     this.render();
   }
 
@@ -41,61 +43,154 @@ export class MatchPicker {
     }
   }
 
-  render() {
-    if (this.entries.length === 0) {
-      this.root.innerHTML = `<div class="hud-empty">No saved matches yet.</div>`;
-      return;
+  // Persist a snapshot from `app.currentMatch` to localStorage. Returns
+  // the stamped entry (with id + savedAt) so the caller can confirm.
+  saveLocal(matchInfo) {
+    if (!matchInfo) return null;
+    const local = this._readLocal();
+    const key = entryKey(matchInfo);
+    const dup = local.find((e) => entryKey(e) === key);
+    if (dup) {
+      this.render();
+      return dup;
     }
-    // Newest first.
-    const sorted = [...this.entries].sort((a, b) => (b.id || 0) - (a.id || 0));
-    this.root.innerHTML = "";
-    for (const entry of sorted) {
-      const row = document.createElement("div");
-      row.className = "match-row";
-      row.dataset.id = entry.id;
-      if (entry.id === this.activeId) row.classList.add("active");
+    const nextN = local.reduce((m, e) => {
+      const match = /^local-(\d+)$/.exec(String(e.id ?? ""));
+      return match ? Math.max(m, parseInt(match[1], 10)) : m;
+    }, 0) + 1;
+    const entry = {
+      id: `local-${nextN}`,
+      savedAt: new Date().toISOString(),
+      map: matchInfo.map ?? "custom",
+      mapConfig: matchInfo.mapConfig,
+      seed: matchInfo.seed,
+      lineup: matchInfo.lineup,
+      lineupTech: matchInfo.lineupTech ?? null,
+      startPositions: matchInfo.startPositions,
+      ticks: 0,
+      flags: [{ tag: "saved", note: "Saved from browser" }],
+    };
+    local.push(entry);
+    this._writeLocal(local);
+    this.localEntries = local;
+    this.render();
+    return entry;
+  }
 
-      const head = document.createElement("div");
-      head.className = "match-row-head";
-      const idEl = document.createElement("span");
-      idEl.className = "match-id";
-      idEl.textContent = `#${entry.id}`;
-      head.appendChild(idEl);
-      const meta = document.createElement("span");
-      meta.textContent = `${entry.map}·${entry.lineup.length}p·t=${entry.ticks}`;
-      head.appendChild(meta);
-      const spacer = document.createElement("span");
-      spacer.style.flex = "1";
-      head.appendChild(spacer);
-      for (const f of entry.flags || []) {
-        const tag = document.createElement("span");
-        tag.className = "match-flag";
-        tag.dataset.tag = f.tag;
-        tag.textContent = f.tag;
-        tag.title = f.note ?? f.tag;
-        head.appendChild(tag);
-      }
+  deleteLocal(id) {
+    const next = this._readLocal().filter((e) => String(e.id) !== String(id));
+    this._writeLocal(next);
+    this.localEntries = next;
+    if (String(this.activeId) === String(id)) this.activeId = null;
+    this.render();
+  }
 
-      const lineup = document.createElement("div");
-      lineup.className = "match-lineup";
-      lineup.textContent = entry.lineup.join(" · ");
-      lineup.title = entry.lineup.join(", ");
-
-      row.appendChild(head);
-      row.appendChild(lineup);
-      row.addEventListener("click", () => {
-        try {
-          this.app._userChoseMode = true;
-          this.setActive(entry.id);
-          this.app.loadReplay(entry);
-        } catch (e) {
-          // Most likely cause: the saved match references a strategy that
-          // was renamed or deleted since the file was written.
-          this.app.controls?.log(`⚠ Replay #${entry.id} failed: ${e.message}`);
-          console.error(e);
-        }
-      });
-      this.root.appendChild(row);
+  _readLocal() {
+    try {
+      const raw = localStorage.getItem(LS_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed?.entries) ? parsed.entries : [];
+    } catch {
+      return [];
     }
   }
+
+  _writeLocal(entries) {
+    try {
+      localStorage.setItem(LS_KEY, JSON.stringify({ entries }));
+    } catch {
+      // localStorage may be disabled or full; surface via the event log.
+      this.app.controls?.log("⚠ Could not persist saved match (localStorage unavailable).");
+    }
+  }
+
+  render() {
+    const all = [...this.serverEntries, ...this.localEntries];
+    if (all.length === 0) {
+      this.root.innerHTML = `<div class="hud-empty">No saved matches yet.<br/><span style="font-size:10px">Press <code>S</code> or click ★ Save to keep one.</span></div>`;
+      return;
+    }
+    // Newest-first, with local saves bubbling on top by `savedAt`.
+    const sorted = all.slice().sort((a, b) => {
+      const ta = a.savedAt ? Date.parse(a.savedAt) : 0;
+      const tb = b.savedAt ? Date.parse(b.savedAt) : 0;
+      if (ta !== tb) return tb - ta;
+      const ia = typeof a.id === "number" ? a.id : 0;
+      const ib = typeof b.id === "number" ? b.id : 0;
+      return ib - ia;
+    });
+    this.root.innerHTML = "";
+    for (const entry of sorted) {
+      this.root.appendChild(this._renderRow(entry));
+    }
+  }
+
+  _renderRow(entry) {
+    const row = document.createElement("div");
+    row.className = "match-row";
+    row.dataset.id = entry.id;
+    if (String(entry.id) === String(this.activeId)) row.classList.add("active");
+    const isLocal = typeof entry.id === "string" && entry.id.startsWith("local-");
+    if (isLocal) row.classList.add("local");
+
+    const head = document.createElement("div");
+    head.className = "match-row-head";
+    const idEl = document.createElement("span");
+    idEl.className = "match-id";
+    idEl.textContent = isLocal ? `★${entry.id.replace("local-", "#")}` : `#${entry.id}`;
+    head.appendChild(idEl);
+    const meta = document.createElement("span");
+    const ticks = entry.ticks ?? 0;
+    meta.textContent = `${entry.map}·${entry.lineup.length}p${ticks ? `·t=${ticks}` : ""}·seed=${entry.seed}`;
+    head.appendChild(meta);
+    const spacer = document.createElement("span");
+    spacer.style.flex = "1";
+    head.appendChild(spacer);
+    for (const f of entry.flags || []) {
+      const tag = document.createElement("span");
+      tag.className = "match-flag";
+      tag.dataset.tag = f.tag;
+      tag.textContent = f.tag;
+      tag.title = f.note ?? f.tag;
+      head.appendChild(tag);
+    }
+    if (isLocal) {
+      const del = document.createElement("button");
+      del.className = "match-delete";
+      del.textContent = "✕";
+      del.title = "Delete saved match";
+      del.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.deleteLocal(entry.id);
+      });
+      head.appendChild(del);
+    }
+
+    const lineup = document.createElement("div");
+    lineup.className = "match-lineup";
+    lineup.textContent = entry.lineup.join(" · ");
+    lineup.title = entry.lineup.join(", ");
+
+    row.appendChild(head);
+    row.appendChild(lineup);
+    row.addEventListener("click", () => {
+      try {
+        this.app._userChoseMode = true;
+        this.setActive(entry.id);
+        this.app.loadReplay(entry);
+      } catch (e) {
+        this.app.controls?.log(`⚠ Replay ${entry.id} failed: ${e.message}`);
+        console.error(e);
+      }
+    });
+    return row;
+  }
+}
+
+// Match identity: same map+seed+lineup → dup. Mirrors the headless
+// `tournament/store.js` definition so server and browser saves stay
+// aligned on what counts as "the same match".
+function entryKey(e) {
+  return `${e.map ?? "custom"}|${e.seed}|${(e.lineup || []).join(",")}`;
 }

--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,23 @@ header.app-header {
   color: var(--text-dim);
 }
 
+.seed-pill {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  background: var(--bg-3);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  border: 1px solid var(--line);
+  transition: border-color 0.12s, color 0.12s;
+}
+
+.seed-pill:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 aside.sidebar {
   grid-area: sidebar;
   background: var(--bg-1);
@@ -530,6 +547,16 @@ select.dropdown {
   border-bottom: 1px solid rgba(255, 255, 255, 0.03);
 }
 
+.log-entry.log-replay {
+  cursor: pointer;
+  color: var(--text);
+  transition: color 0.12s;
+}
+
+.log-entry.log-replay:hover {
+  color: var(--accent);
+}
+
 .hud-empty {
   color: var(--text-dim);
   font-style: italic;
@@ -621,6 +648,32 @@ select.dropdown {
 .match-flag[data-tag="close-finish"] { color: #6ee7ff; border-color: rgba(110, 231, 255, 0.4); }
 .match-flag[data-tag="runaway"] { color: #ff4d6d; border-color: rgba(255, 77, 109, 0.4); }
 .match-flag[data-tag="mutual-destruction"] { color: #f97aff; border-color: rgba(249, 122, 255, 0.4); }
+.match-flag[data-tag="saved"] { color: #ffe066; border-color: rgba(255, 224, 102, 0.4); }
+
+.match-row.local {
+  border-left: 2px solid #ffe066;
+}
+
+.match-row.local .match-id {
+  color: #ffe066;
+}
+
+.match-delete {
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--text-dim);
+  border-radius: 3px;
+  padding: 0 5px;
+  font-size: 10px;
+  cursor: pointer;
+  margin-left: 4px;
+  line-height: 1.4;
+}
+
+.match-delete:hover {
+  border-color: var(--danger);
+  color: var(--danger);
+}
 
 .match-lineup {
   font-size: 10px;


### PR DESCRIPTION
- Show the active seed in a header pill (click to copy) and in the
  mode-description line so it's no longer invisible. Rename "Reset" to
  "New seed" with an explanatory tooltip and add a paired "Replay"
  button (and L key) that re-runs with the same seed.
- Add a "Save" button (and S key) that persists the current match —
  seed, lineup, map config, start positions — to localStorage, where
  the saved-matches panel merges it with the headless tournament's
  interesting.json. Local entries are flagged "saved", get a yellow
  accent, and can be deleted from the row.
- Make winner / mutual-destruction log entries clickable: clicking a
  log line replays that exact match (uses currentMatch snapshotted at
  the time the line was logged).
- Rankings tier buttons now respect modifiers — plain click replaces,
  shift-click extends a range, ctrl/cmd-click toggles a tier in/out.
  Shift-click on a bot row selects the range from the last clicked row
  through the current one.
- Toggling rows no longer rebuilds the ranking-list, so the user's
  scroll position is preserved across selection changes.

https://claude.ai/code/session_013h6jFhTnSczyuy8VK6PdSw