### PR TITLE
Add View-code button on bots and a Try-a-bot paste-and-run flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
       <div class="brand">PixelWars</div>
       <div class="brand-sub">Tile Strategy Sandbox</div>
       <div class="header-spacer"></div>
+      <button id="btn-try-bot" class="btn" title="Paste a bot script and seat it in the next match">⚙ Try a bot</button>
       <span class="tick-pill" id="tick-label">t=0</span>
       <span class="kbd">Space</span><span class="brand-sub">play</span>
       <span class="kbd">.</span><span class="brand-sub">step</span>

--- a/src/client/EngineClient.js
+++ b/src/client/EngineClient.js
@@ -71,7 +71,7 @@ export class EngineClient {
   // before the first snapshot arrives.
   // ------------------------------------------------------------------
 
-  loadCustom({ mapConfig, lineupStrategies, startPositions, seed }) {
+  loadCustom({ mapConfig, lineupStrategies, startPositions, seed, customStrategies = [] }) {
     const palette = PALETTE.slice(0, lineupStrategies.length);
     const lineup = lineupStrategies.map((s) => s.name);
     this._primeView({
@@ -86,6 +86,7 @@ export class EngineClient {
       palette,
       startPositions,
       seed,
+      customStrategies,
     });
   }
 

--- a/src/engine/host.js
+++ b/src/engine/host.js
@@ -52,6 +52,10 @@ export class EngineHost {
     this._minTick = 30; // matches main.js winner heuristic
     this._initSpec = null;
     this._overlayEnabled = false;
+    // Strategies the user pasted via "Try a bot". Source code arrives
+    // in the init payload; we eval each one to a real strategy object
+    // exactly once, then look it up by name when seating players.
+    this._customStrategies = new Map();
     this._timeNow = typeof performance !== "undefined" && performance.now
       ? () => performance.now()
       : () => Date.now();
@@ -73,30 +77,37 @@ export class EngineHost {
     if (this.game) this._postSnapshot(this._timeNow());
   }
 
-  initCustom(spec) {
+  async initCustom(spec) {
     // spec: { mapConfig, lineup: [strategyName], palette, numPlayers, seed,
-    //         startPositions? }
+    //         startPositions?, customStrategies? }
     this._initSpec = { kind: "custom", spec };
+    await this._registerCustom(spec.customStrategies);
     this._buildGame(spec);
     this._snapshotPending = true;
     this.emit(EVT_PLAYERS_CHANGED, { players: this._serializePlayers() });
     this._postSnapshot(this._timeNow());
   }
 
-  initReplay(spec) {
+  async initReplay(spec) {
     // spec: { mapConfig, seed, lineup: [strategyName], lineupTech,
     //         startPositions, palette }
     this._initSpec = { kind: "replay", spec };
+    await this._registerCustom(spec.customStrategies);
     this._buildReplay(spec);
     this._snapshotPending = true;
     this.emit(EVT_PLAYERS_CHANGED, { players: this._serializePlayers() });
     this._postSnapshot(this._timeNow());
   }
 
-  reset() {
+  async reset() {
     if (!this._initSpec) return;
-    if (this._initSpec.kind === "custom") this._buildGame(this._initSpec.spec);
-    else this._buildReplay(this._initSpec.spec);
+    if (this._initSpec.kind === "custom") {
+      await this._registerCustom(this._initSpec.spec.customStrategies);
+      this._buildGame(this._initSpec.spec);
+    } else {
+      await this._registerCustom(this._initSpec.spec.customStrategies);
+      this._buildReplay(this._initSpec.spec);
+    }
     this._lastWinnerLogged = null;
     this._snapshotPending = true;
     this.emit(EVT_PLAYERS_CHANGED, { players: this._serializePlayers() });
@@ -124,11 +135,37 @@ export class EngineHost {
 
   // --- Internals ----------------------------------------------------------
 
+  // Convert pasted-bot source into runnable strategy objects. Each
+  // entry is loaded via a Blob URL so dynamic import() can pull the
+  // module's default export. We cache by name+code so reset and
+  // re-init don't re-import the same source.
+  async _registerCustom(customStrategies) {
+    if (!customStrategies || customStrategies.length === 0) return;
+    for (const { name, code } of customStrategies) {
+      const existing = this._customStrategies.get(name);
+      if (existing && existing.__sourceCode === code) continue;
+      const blob = new Blob([code], { type: "application/javascript" });
+      const url = URL.createObjectURL(blob);
+      try {
+        const mod = await import(/* webpackIgnore: true */ url);
+        const def = mod.default;
+        if (!def || typeof def.act !== "function") {
+          throw new Error(`Custom bot ${name}: default export missing act()`);
+        }
+        def.name = name;
+        def.__sourceCode = code;
+        this._customStrategies.set(name, def);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
+    }
+  }
+
   _buildGame(spec) {
     const { mapConfig, lineup, palette, startPositions, seed } = spec;
     this.game = new Game({ ...mapConfig, seed });
     const strategies = lineup.map((name) => {
-      const s = ALL_STRATEGIES[name];
+      const s = this._customStrategies.get(name) ?? ALL_STRATEGIES[name];
       if (!s) throw new Error(`Unknown strategy: ${name}`);
       return s;
     });
@@ -152,7 +189,7 @@ export class EngineHost {
   _buildReplay(spec) {
     const { mapConfig, seed, lineup, lineupTech, startPositions, palette } = spec;
     const strategies = lineup.map((name) => {
-      const s = ALL_STRATEGIES[name];
+      const s = this._customStrategies.get(name) ?? ALL_STRATEGIES[name];
       if (!s) throw new Error(`Replay references unknown strategy: ${name}`);
       return s;
     });

--- a/src/engine/worker.js
+++ b/src/engine/worker.js
@@ -21,15 +21,19 @@ const host = new EngineHost({
 
 self.addEventListener("message", (e) => {
   const { type, payload } = e.data || {};
+  const log = (err) => self.postMessage({
+    type: "log",
+    payload: `engine: ${err?.message ?? String(err)}`,
+  });
   switch (type) {
     case MSG_INIT_CUSTOM:
-      host.initCustom(payload);
+      Promise.resolve(host.initCustom(payload)).catch(log);
       break;
     case MSG_INIT_REPLAY:
-      host.initReplay(payload);
+      Promise.resolve(host.initReplay(payload)).catch(log);
       break;
     case MSG_RESET:
-      host.reset();
+      Promise.resolve(host.reset()).catch(log);
       break;
     case MSG_SET_PLAYING:
       host.setPlaying(!!payload);

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,9 @@ import { MatchPicker } from "./ui/MatchPicker.js";
 import { LeagueViewer } from "./ui/LeagueViewer.js";
 import { SeasonViewer } from "./ui/SeasonViewer.js";
 import { MapEditor } from "./ui/MapEditor.js";
+import { CodeModal } from "./ui/CodeModal.js";
+import { CustomBots, loadStrategyFromCode } from "./ui/CustomBots.js";
+import { getStrategySource } from "./ui/strategySource.js";
 import { ALL_STRATEGIES, STRATEGY_LIST } from "./strategies/index.js";
 
 class App {
@@ -58,6 +61,10 @@ class App {
     // Tracks whether the user has already touched the controls so the
     // async rankings loader doesn't yank them out of an active view.
     this._userChoseMode = false;
+
+    this.customBots = new CustomBots();
+    this.codeModal = new CodeModal();
+    this._bindTryBotButton();
 
     this.matchPicker = new MatchPicker({
       root: document.getElementById("match-picker"),
@@ -143,9 +150,10 @@ class App {
     //   - fixedLineup=true: use the names in order (Reset path).
     //   - otherwise: sample numPlayers random names from the pool.
     // No botNames → top of STRATEGY_LIST.
+    const lookupBot = (n) => this.customBots.getStrategy(n) ?? ALL_STRATEGIES[n];
     let strategies;
     if (botNames) {
-      const pool = botNames.map((n) => ALL_STRATEGIES[n]).filter(Boolean);
+      const pool = botNames.map(lookupBot).filter(Boolean);
       if (fixedLineup) {
         if (pool.length < numPlayers) {
           throw new Error(`Saved lineup has ${pool.length} valid bots; need ${numPlayers}`);
@@ -163,7 +171,12 @@ class App {
         }
       }
     } else {
-      strategies = STRATEGY_LIST.slice(0, numPlayers);
+      // Default lineup: any pasted custom bots take the front slots so a
+      // fresh "Use in match" actually shows up without manual setup.
+      const customs = this.customBots.list().map((e) => e.strategy);
+      const corePool = STRATEGY_LIST.filter((s) => !this.customBots.has(s.name));
+      const merged = [...customs, ...corePool];
+      strategies = merged.slice(0, numPlayers);
       if (strategies.length < numPlayers) {
         throw new Error(`Not enough strategies for ${numPlayers} players`);
       }
@@ -198,6 +211,7 @@ class App {
       lineupStrategies: strategies,
       startPositions,
       seed,
+      customStrategies: this.customBots.serializeUsed(strategies.map((s) => s.name)),
     });
     this.renderer.resize();
     this.chart.resize();
@@ -317,6 +331,62 @@ class App {
     } else {
       this.loadCustomMap(this.mapEditor.read());
     }
+  }
+
+  _bindTryBotButton() {
+    const btn = document.getElementById("btn-try-bot");
+    if (!btn) return;
+    btn.addEventListener("click", () => {
+      this.codeModal.openEdit({
+        onSubmit: ({ name, code }) => this.useCustomBot({ name, code }),
+      });
+    });
+  }
+
+  // Open the read-only code viewer for a strategy by name. Looks at
+  // pasted bots first, then falls back to fetching the file from disk
+  // (or to act.toString() for factory-built bots).
+  async viewStrategyCode(name) {
+    const strategy = this.customBots.getStrategy(name) ?? ALL_STRATEGIES[name];
+    if (!strategy) return;
+    this.codeModal.openView({
+      title: name,
+      subtitle: "Loading source…",
+      code: "",
+    });
+    const { source, origin } = await getStrategySource(strategy, { customBots: this.customBots });
+    const subtitle = origin === "custom"
+      ? "Custom bot from this session."
+      : origin === "act-toString"
+        ? "Source not on disk; showing act() as compiled."
+        : `From ${origin}`;
+    this.codeModal.openView({ title: name, subtitle, code: source });
+  }
+
+  // Validate and register a pasted bot, then immediately reload the
+  // current map with the new bot seated in slot 0. Subsequent random
+  // pools also include it.
+  async useCustomBot({ name, code }) {
+    let strategy;
+    try {
+      strategy = await loadStrategyFromCode(code);
+    } catch (err) {
+      throw new Error(`Couldn't load module: ${err.message}`);
+    }
+    this.customBots.add({ name, code, strategy });
+    this._userChoseMode = true;
+    const config = this.mapEditor.read();
+    const { numPlayers } = config;
+    const otherCustoms = this.customBots
+      .list()
+      .map((e) => e.name)
+      .filter((n) => n !== name);
+    const corePool = STRATEGY_LIST.map((s) => s.name)
+      .filter((n) => !this.customBots.has(n));
+    const fillers = [...otherCustoms, ...corePool].slice(0, Math.max(0, numPlayers - 1));
+    const botNames = [name, ...fillers];
+    this.loadCustomMap({ ...config, botNames, fixedLineup: true });
+    this.controls.log(`⚙ Loaded custom bot "${name}" — seated in slot 1`);
   }
 
   markDirty() {

--- a/src/render/Renderer.js
+++ b/src/render/Renderer.js
@@ -91,7 +91,7 @@ export class Renderer {
     const ts = this.tileSize;
     for (const tile of this.game.map.tiles) {
       const owner = tile.ownerArmy();
-      if (!owner) continue;
+      if (!owner || !owner.player) continue;
       const alpha = 0.10 + 0.20 * (owner.strength / owner.maxStrength);
       ctx.fillStyle = hexToRgba(owner.player.color, alpha);
       ctx.fillRect(tile.pos.x * ts, tile.pos.y * ts, ts, ts);
@@ -155,6 +155,7 @@ export class Renderer {
     const exponent = 0.7;
     for (const army of this.game.armies) {
       if (!army.alive) continue;
+      if (!army.player) continue;
       if (!army.bornAt) army.bornAt = now;
       const ratio = Math.max(0, Math.min(1, army.strength / army.maxStrength));
       const radiusFactor = minRadius + (maxRadius - minRadius) * Math.pow(ratio, exponent);

--- a/src/ui/CodeModal.js
+++ b/src/ui/CodeModal.js
@@ -1,0 +1,192 @@
+// Single shared modal used for two flows:
+//   - "View code": read-only display of an existing strategy's source.
+//   - "Try a bot": paste/upload a bot script, name it, run it in a match.
+//
+// The modal is created lazily and reused. Only one instance is open
+// at a time; opening with a different mode replaces the contents.
+
+const SAMPLE_BOT = `// Paste a strategy module here. Must be self-contained: no imports
+// (the worker can't resolve relative paths from your paste). The
+// 'act' callback runs every tick on each of your armies.
+//
+// API quick reference:
+//   army.tile.neighbors[i] -> tile in direction i (0..3) or null
+//   army.attack(tile, power) -> commit 'power' strength toward 'tile'
+//   army.attackPower         -> max usable strength this tick
+//   army.player.id           -> your own player id
+//   game.rng()               -> deterministic [0,1) random
+//   game.tick                -> current tick count
+
+export default {
+  name: "MyBot",
+  description: "Random walk that always pushes hard.",
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const dir = (game.rng() * 4) | 0;
+    const target = tile.neighbors[dir];
+    if (!target) return;
+    army.attack(target, army.attackPower);
+  },
+};
+`;
+
+export class CodeModal {
+  constructor() {
+    this.root = null;
+    this.onSubmit = null;
+    this._build();
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && this.root && this.root.style.display !== "none") {
+        this.close();
+      }
+    });
+  }
+
+  _build() {
+    const root = document.createElement("div");
+    root.className = "code-modal-root";
+    root.style.display = "none";
+    root.innerHTML = `
+      <div class="code-modal-backdrop"></div>
+      <div class="code-modal" role="dialog" aria-modal="true">
+        <div class="code-modal-head">
+          <div class="code-modal-title"></div>
+          <button class="code-modal-close" aria-label="Close">×</button>
+        </div>
+        <div class="code-modal-subtitle"></div>
+        <div class="code-modal-form">
+          <label class="code-modal-name-row">
+            <span>Bot name</span>
+            <input class="code-modal-name" type="text" placeholder="MyBot" />
+          </label>
+        </div>
+        <textarea class="code-modal-code" spellcheck="false" wrap="off"></textarea>
+        <div class="code-modal-error"></div>
+        <div class="code-modal-foot">
+          <div class="code-modal-foot-left">
+            <label class="code-modal-upload">
+              <input type="file" class="code-modal-file" accept=".js,.mjs,text/javascript" />
+              <span class="btn">📂 Upload .js</span>
+            </label>
+          </div>
+          <div class="code-modal-foot-right">
+            <button class="btn code-modal-cancel">Cancel</button>
+            <button class="btn primary code-modal-submit">Use in match</button>
+          </div>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(root);
+
+    this.root = root;
+    this.titleEl = root.querySelector(".code-modal-title");
+    this.subtitleEl = root.querySelector(".code-modal-subtitle");
+    this.formEl = root.querySelector(".code-modal-form");
+    this.nameEl = root.querySelector(".code-modal-name");
+    this.codeEl = root.querySelector(".code-modal-code");
+    this.errEl = root.querySelector(".code-modal-error");
+    this.footEl = root.querySelector(".code-modal-foot");
+    this.submitEl = root.querySelector(".code-modal-submit");
+    this.cancelEl = root.querySelector(".code-modal-cancel");
+    this.fileEl = root.querySelector(".code-modal-file");
+
+    root.querySelector(".code-modal-backdrop").addEventListener("click", () => this.close());
+    root.querySelector(".code-modal-close").addEventListener("click", () => this.close());
+    this.cancelEl.addEventListener("click", () => this.close());
+    this.submitEl.addEventListener("click", () => this._submit());
+    this.fileEl.addEventListener("change", (e) => this._onFile(e));
+  }
+
+  openView({ title, subtitle = "", code }) {
+    this._setMode("view");
+    this.titleEl.textContent = title;
+    this.subtitleEl.textContent = subtitle;
+    this.codeEl.value = code ?? "";
+    this.codeEl.scrollTop = 0;
+    this.errEl.textContent = "";
+    this._show();
+  }
+
+  openEdit({ title = "Try a bot", subtitle = "Paste a strategy module. It runs in your browser only — clears on refresh.", initialCode = SAMPLE_BOT, initialName = "MyBot", onSubmit }) {
+    this._setMode("edit");
+    this.titleEl.textContent = title;
+    this.subtitleEl.textContent = subtitle;
+    this.codeEl.value = initialCode;
+    this.nameEl.value = initialName;
+    this.errEl.textContent = "";
+    this.onSubmit = onSubmit;
+    this._show();
+    setTimeout(() => this.nameEl.focus(), 0);
+  }
+
+  setError(msg) {
+    this.errEl.textContent = msg ?? "";
+  }
+
+  close() {
+    if (!this.root) return;
+    this.root.style.display = "none";
+    this.onSubmit = null;
+  }
+
+  _show() {
+    this.root.style.display = "block";
+  }
+
+  _setMode(mode) {
+    const editing = mode === "edit";
+    this.codeEl.readOnly = !editing;
+    this.codeEl.classList.toggle("readonly", !editing);
+    this.formEl.style.display = editing ? "" : "none";
+    this.footEl.style.display = editing ? "" : "none";
+    this.cancelEl.textContent = editing ? "Cancel" : "Close";
+  }
+
+  async _submit() {
+    if (!this.onSubmit) return this.close();
+    const name = (this.nameEl.value || "").trim();
+    const code = this.codeEl.value;
+    if (!name) {
+      this.setError("Name is required.");
+      this.nameEl.focus();
+      return;
+    }
+    if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(name)) {
+      this.setError("Name must start with a letter and use only letters, digits, _.");
+      this.nameEl.focus();
+      return;
+    }
+    if (!code.trim()) {
+      this.setError("Paste a strategy module.");
+      this.codeEl.focus();
+      return;
+    }
+    this.submitEl.disabled = true;
+    try {
+      await this.onSubmit({ name, code });
+      this.close();
+    } catch (err) {
+      this.setError(err?.message ?? String(err));
+    } finally {
+      this.submitEl.disabled = false;
+    }
+  }
+
+  async _onFile(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      this.codeEl.value = text;
+      if (!this.nameEl.value) {
+        const guess = file.name.replace(/\.(m?js)$/i, "");
+        if (/^[A-Za-z][A-Za-z0-9_]*$/.test(guess)) this.nameEl.value = guess;
+      }
+    } catch (err) {
+      this.setError("Couldn't read file: " + err.message);
+    } finally {
+      e.target.value = "";
+    }
+  }
+}

--- a/src/ui/CustomBots.js
+++ b/src/ui/CustomBots.js
@@ -1,0 +1,94 @@
+// In-memory registry of bots the user has pasted in this session.
+//
+// Persistence is intentionally session-scoped (no localStorage): the
+// trust model for paste-and-run is "the user is running their own
+// code in their own browser", and the friction of re-pasting is a
+// reasonable forcing function until the roadmap's iframe sandbox
+// lands. Survives Reset, lost on refresh.
+
+export class CustomBots {
+  constructor() {
+    this.entries = new Map();
+    this._listeners = new Set();
+  }
+
+  add({ name, code, strategy }) {
+    if (!name) throw new Error("Custom bot needs a name");
+    if (!strategy || typeof strategy.act !== "function") {
+      throw new Error("Custom bot must export { act } as default");
+    }
+    strategy.name = name;
+    strategy.author = strategy.author ?? "you";
+    this.entries.set(name, { name, code, strategy });
+    this._emit();
+    return strategy;
+  }
+
+  remove(name) {
+    if (!this.entries.delete(name)) return false;
+    this._emit();
+    return true;
+  }
+
+  has(name) {
+    return this.entries.has(name);
+  }
+
+  getStrategy(name) {
+    return this.entries.get(name)?.strategy ?? null;
+  }
+
+  getCode(name) {
+    return this.entries.get(name)?.code ?? null;
+  }
+
+  list() {
+    return [...this.entries.values()];
+  }
+
+  // Returns the wire payload the engine worker needs to recreate the
+  // bot inside the simulation worker (eval via Blob URL + import()).
+  // Only includes bots that are referenced in `usedNames` so we don't
+  // ship every paste across the boundary.
+  serializeUsed(usedNames) {
+    const out = [];
+    for (const name of usedNames) {
+      const e = this.entries.get(name);
+      if (e) out.push({ name: e.name, code: e.code });
+    }
+    return out;
+  }
+
+  onChange(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
+  }
+
+  _emit() {
+    for (const fn of this._listeners) {
+      try { fn(); } catch {}
+    }
+  }
+}
+
+// Loads pasted source as an ES module via a Blob URL and returns its
+// default export. Runs on the main thread, used to validate the
+// shape before we ship the code into the engine worker — that way
+// errors surface in the modal, not as a worker crash.
+export async function loadStrategyFromCode(code) {
+  const blob = new Blob([code], { type: "application/javascript" });
+  const url = URL.createObjectURL(blob);
+  try {
+    const mod = await import(/* @vite-ignore */ url);
+    const def = mod.default;
+    if (!def || typeof def !== "object") {
+      throw new Error("Module must `export default` a strategy object.");
+    }
+    if (typeof def.act !== "function") {
+      throw new Error("Strategy default export must have an `act(army, game)` function.");
+    }
+    return def;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -37,13 +37,22 @@ export class HUD {
     const strat = player.strategy;
     const title = strat?.name ?? player.name ?? "";
     const body = strat?.summary || strat?.description || "";
+    const showCodeBtn = !!strat?.name;
     this.tooltip.innerHTML = `
       <div class="strat-tooltip-title">${escapeHtml(title)}</div>
       ${body ? `<div class="strat-tooltip-body">${escapeHtml(body)}</div>` : ""}
       ${renderTechLoadout(player)}
+      ${showCodeBtn ? `<button class="btn-mini strat-tooltip-code" data-strat-name="${escapeHtml(strat.name)}">&lt;/&gt; View code</button>` : ""}
     `;
     this.tooltip.style.setProperty("--player-color", player.color);
     this.tooltip.style.display = "block";
+    if (showCodeBtn) {
+      const btn = this.tooltip.querySelector(".strat-tooltip-code");
+      btn?.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.app?.viewStrategyCode?.(strat.name);
+      });
+    }
     this.positionTooltip(row);
   }
 

--- a/src/ui/strategySource.js
+++ b/src/ui/strategySource.js
@@ -1,0 +1,43 @@
+// Resolves the source code for a strategy by name.
+//
+// Most bots live in their own file under `src/strategies/` (filename
+// matches `strategy.name`), so we just fetch that. A handful are
+// declared inline (factory output in `generated.js`, parametric
+// variants under `src/strategies/parametric/`) — for those we fall
+// back to `String(strategy.act)`, which is honest about what's
+// actually being run even if it loses helper imports.
+
+const FETCH_BASES = ["src/strategies/", "src/strategies/parametric/"];
+const fetchCache = new Map();
+
+async function tryFetch(path) {
+  if (fetchCache.has(path)) return fetchCache.get(path);
+  const promise = fetch(path, { cache: "no-cache" })
+    .then((r) => (r.ok ? r.text() : null))
+    .catch(() => null);
+  fetchCache.set(path, promise);
+  return promise;
+}
+
+export async function getStrategySource(strategy, { customBots } = {}) {
+  if (!strategy) return { source: "", origin: "missing" };
+
+  if (customBots) {
+    const custom = customBots.getCode(strategy.name);
+    if (custom != null) return { source: custom, origin: "custom" };
+  }
+
+  for (const base of FETCH_BASES) {
+    const path = `${base}${strategy.name}.js`;
+    const text = await tryFetch(path);
+    if (text != null) return { source: text, origin: path };
+  }
+
+  if (typeof strategy.act === "function") {
+    const body = strategy.act.toString();
+    const meta = `// ${strategy.name}\n// (factory-built; showing act() body — closure-bound helpers omitted)\n\n`;
+    return { source: meta + body, origin: "act-toString" };
+  }
+
+  return { source: "// (no source available)", origin: "missing" };
+}

--- a/styles.css
+++ b/styles.css
@@ -554,6 +554,166 @@ select.dropdown {
   gap: 4px;
 }
 
+.strat-tooltip-code {
+  margin-top: 10px;
+  display: block;
+  width: 100%;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+}
+
+.code-modal-root {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+}
+
+.code-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(4, 6, 12, 0.7);
+  backdrop-filter: blur(2px);
+}
+
+.code-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(880px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.code-modal-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 6px;
+  gap: 12px;
+}
+
+.code-modal-title {
+  font-weight: 800;
+  font-size: 16px;
+  letter-spacing: 1px;
+  color: var(--text);
+  text-transform: uppercase;
+}
+
+.code-modal-close {
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  font-size: 22px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+
+.code-modal-close:hover {
+  color: var(--text);
+}
+
+.code-modal-subtitle {
+  padding: 0 18px 8px;
+  font-size: 11px;
+  color: var(--text-dim);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.code-modal-form {
+  padding: 0 18px 8px;
+}
+
+.code-modal-name-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+
+.code-modal-name {
+  flex: 1;
+  background: var(--bg-3);
+  color: var(--text);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+}
+
+.code-modal-code {
+  flex: 1;
+  margin: 0 18px;
+  background: #06090f;
+  color: #c8d1e0;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 12px 14px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  resize: vertical;
+  min-height: 320px;
+  white-space: pre;
+  outline: none;
+}
+
+.code-modal-code.readonly {
+  cursor: text;
+  color: #d6dee9;
+}
+
+.code-modal-error {
+  padding: 6px 18px 0;
+  color: var(--danger);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  min-height: 14px;
+  white-space: pre-wrap;
+}
+
+.code-modal-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px 14px;
+  gap: 10px;
+}
+
+.code-modal-foot-left,
+.code-modal-foot-right {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.code-modal-upload {
+  position: relative;
+  display: inline-block;
+}
+
+.code-modal-upload input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+#btn-try-bot {
+  font-size: 12px;
+  padding: 6px 10px;
+}
+
 .match-picker-head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Click any player's strategy tooltip to see its source — fetched from
src/strategies/<name>.js when present, or the act() body via toString
for factory-built bots. The header's "Try a bot" button opens a modal
that takes a name and a JS module body (or .js upload), validates by
loading it through a Blob URL on the main thread, and re-runs the
current map with the bot seated in slot 0. Pasted bots live for the
session only; the engine worker reloads each unique source via
URL.createObjectURL + dynamic import so the simulation actually runs
the user's code without leaving the existing worker boundary.

Also harden the renderer against stale snapshots whose army.player ref
points at a player from the previous game — possible during a reload
race that the now-async init makes slightly more visible. The roadmap's
iframe sandbox is still required before any sharing path; this is the
local-only "your own gun" lane.