### PR TITLE
Add shareable URL support for match configurations

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,7 @@ import { MapEditor } from "./ui/MapEditor.js";
 import { CodeModal } from "./ui/CodeModal.js";
 import { CustomBots, loadStrategyFromCode } from "./ui/CustomBots.js";
 import { getStrategySource } from "./ui/strategySource.js";
+import { readUrlMatchInfo, updateUrl } from "./ui/shareLink.js";
 import { ALL_STRATEGIES, STRATEGY_LIST } from "./strategies/index.js";
 
 class App {
@@ -77,12 +78,17 @@ class App {
       app: this,
     });
     this.mapEditor = new MapEditor({ app: this });
-    // Initial match: seed the canvas with default form values + top of
-    // STRATEGY_LIST so something renders before rankings.json loads.
-    this.loadCustomMap(this.mapEditor.read());
-    // Reset the override flag so the rankings loader can replace the
-    // initial canvas with a top-tier match once rankings.json arrives.
-    this._userChoseMode = false;
+    // Initial match: prefer a shared URL if one is present, otherwise
+    // seed the canvas with default form values + top of STRATEGY_LIST
+    // so something renders before rankings.json loads.
+    const urlInfo = readUrlMatchInfo();
+    const loadedFromUrl = urlInfo ? this._tryLoadFromUrl(urlInfo) : false;
+    if (!loadedFromUrl) {
+      this.loadCustomMap(this.mapEditor.read());
+      // Reset the override flag so the rankings loader can replace the
+      // initial canvas with a top-tier match once rankings.json arrives.
+      this._userChoseMode = false;
+    }
     this.leagueViewer = new LeagueViewer({
       root: document.getElementById("league-viewer"),
       refreshButton: document.getElementById("btn-leagues-refresh"),
@@ -154,6 +160,7 @@ class App {
     this.bindCanvas();
     this._setPlayingLocal(true);
     this.markDirty();
+    updateUrl(this.currentMatch);
   }
 
   loadCustomMap({ width, height, growth, maxArmy, wrap, numPlayers, botNames = null, fixedLineup = false, seed = null, startPositions = null }) {
@@ -254,6 +261,50 @@ class App {
     this.bindCanvas();
     this._setPlayingLocal(true);
     this.markDirty();
+    updateUrl(this.currentMatch);
+  }
+
+  // Best-effort load of a match described by URL query params. Returns
+  // true on success, false if the URL doesn't carry enough info or if
+  // any referenced bot isn't available — in which case the caller falls
+  // back to the default startup flow.
+  _tryLoadFromUrl(info) {
+    if (!info || !info.mapConfig) return false;
+    const c = info.mapConfig;
+    const lookupBot = (n) => this.customBots.getStrategy(n) ?? ALL_STRATEGIES[n];
+    const hasLineup = Array.isArray(info.lineup) && info.lineup.length > 0;
+    if (hasLineup && info.lineup.some((n) => !lookupBot(n))) {
+      console.warn("Shared link references unknown bot(s); using defaults.", info.lineup);
+      return false;
+    }
+    const numPlayers = hasLineup ? info.lineup.length : null;
+    this.mapEditor.write({
+      width: c.width,
+      height: c.height,
+      growth: c.growth,
+      maxArmy: c.maxArmy,
+      wrap: c.wrap,
+      numPlayers,
+    });
+    this._userChoseMode = true;
+    try {
+      this.loadCustomMap({
+        width: c.width,
+        height: c.height,
+        growth: c.growth,
+        maxArmy: c.maxArmy,
+        wrap: !!c.wrap,
+        numPlayers: numPlayers ?? this.mapEditor.read().numPlayers,
+        botNames: hasLineup ? info.lineup : null,
+        fixedLineup: hasLineup,
+        seed: info.seed,
+        startPositions: info.startPositions,
+      });
+      return true;
+    } catch (err) {
+      console.warn("Couldn't load shared match from URL:", err);
+      return false;
+    }
   }
 
   // Snapshot the current match in a form ready for `loadFromMatchInfo` or

--- a/src/ui/MapEditor.js
+++ b/src/ui/MapEditor.js
@@ -67,6 +67,18 @@ export class MapEditor {
       wrap: !!this.wrap.checked,
     };
   }
+
+  // Sync form fields from an external config (e.g. URL-loaded match)
+  // without firing the change handlers — the caller is already doing
+  // its own load and shouldn't be rebounded back into applyMapForm.
+  write({ width, height, growth, maxArmy, wrap, numPlayers }) {
+    if (width != null) this.width.value = width;
+    if (height != null) this.height.value = height;
+    if (growth != null) this.growth.value = growth;
+    if (maxArmy != null) this.maxArmy.value = maxArmy;
+    if (wrap != null) this.wrap.checked = !!wrap;
+    if (numPlayers != null) this.players.value = numPlayers;
+  }
 }
 
 function clampInt(raw, lo, hi, fallback) {

--- a/src/ui/shareLink.js
+++ b/src/ui/shareLink.js
@@ -1,0 +1,94 @@
+// Sync the URL query string with the active match so links can be
+// shared. The same params drive the initial load on page open.
+//
+// Encoded fields (all optional, but width+height anchor the load):
+//   w, h        - map width/height
+//   g           - growth
+//   m           - maxArmy
+//   wrap        - "1" if wrap, omitted otherwise
+//   seed        - rng seed
+//   bots        - comma-separated lineup names
+//   pos         - comma-separated "x.y" pairs for start positions
+//
+// Decoding tolerates missing/garbage values: only `w` and `h` are
+// required to take over from defaults; the rest fall back to sensible
+// values handled by loadCustomMap.
+
+export function encodeMatchInfo(info) {
+  const params = new URLSearchParams();
+  if (!info || !info.mapConfig) return params;
+  const c = info.mapConfig;
+  params.set("w", String(c.width));
+  params.set("h", String(c.height));
+  params.set("g", String(c.growth));
+  params.set("m", String(c.maxArmy));
+  if (c.wrap) params.set("wrap", "1");
+  if (info.seed != null) params.set("seed", String(info.seed >>> 0));
+  if (Array.isArray(info.lineup) && info.lineup.length > 0) {
+    params.set("bots", info.lineup.join(","));
+  }
+  if (Array.isArray(info.startPositions) && info.startPositions.length > 0) {
+    params.set(
+      "pos",
+      info.startPositions.map(({ x, y }) => `${x}.${y}`).join(","),
+    );
+  }
+  return params;
+}
+
+export function decodeMatchInfo(searchParams) {
+  const w = parseInt(searchParams.get("w"), 10);
+  const h = parseInt(searchParams.get("h"), 10);
+  if (!Number.isFinite(w) || !Number.isFinite(h)) return null;
+  const growthRaw = parseFloat(searchParams.get("g"));
+  const maxArmyRaw = parseInt(searchParams.get("m"), 10);
+  const wrap = searchParams.get("wrap") === "1";
+  const seedRaw = searchParams.get("seed");
+  const seed = seedRaw != null && seedRaw !== "" ? Number(seedRaw) >>> 0 : null;
+  const botsRaw = searchParams.get("bots");
+  const lineup = botsRaw
+    ? botsRaw.split(",").map((s) => s.trim()).filter(Boolean)
+    : [];
+  const posRaw = searchParams.get("pos");
+  let startPositions = null;
+  if (posRaw) {
+    const parsed = posRaw
+      .split(",")
+      .map((pair) => {
+        const [x, y] = pair.split(".").map((n) => parseInt(n, 10));
+        if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+        return { x, y };
+      })
+      .filter(Boolean);
+    if (parsed.length > 0) startPositions = parsed;
+  }
+  return {
+    mapConfig: {
+      width: w,
+      height: h,
+      growth: Number.isFinite(growthRaw) ? growthRaw : 1.8,
+      maxArmy: Number.isFinite(maxArmyRaw) ? maxArmyRaw : 6,
+      wrap,
+    },
+    seed,
+    lineup,
+    startPositions,
+  };
+}
+
+export function readUrlMatchInfo() {
+  if (typeof window === "undefined") return null;
+  return decodeMatchInfo(new URLSearchParams(window.location.search));
+}
+
+// Replace the current URL's query string with one derived from `info`.
+// Uses replaceState so back/forward history doesn't fill up with each
+// new seed; the URL is for sharing, not navigation.
+export function updateUrl(info) {
+  if (typeof window === "undefined") return;
+  const params = encodeMatchInfo(info);
+  const qs = params.toString();
+  const { pathname, hash } = window.location;
+  const url = qs ? `${pathname}?${qs}${hash}` : `${pathname}${hash}`;
+  window.history.replaceState(null, "", url);
+}


### PR DESCRIPTION
## Summary
This PR adds the ability to share match configurations via URL query parameters. Players can now generate a link that encodes the current map settings, bot lineup, seed, and starting positions, allowing others to load the exact same match by visiting that link.

## Key Changes
- **New `shareLink.js` module**: Implements URL encoding/decoding for match information
  - `encodeMatchInfo()`: Converts match state to URL query parameters (w, h, g, m, wrap, seed, bots, pos)
  - `decodeMatchInfo()`: Parses query parameters back into match configuration with sensible fallbacks
  - `readUrlMatchInfo()`: Reads and decodes match info from current page URL
  - `updateUrl()`: Updates browser history with encoded match info using `replaceState`

- **Updated `main.js`**: Integrates URL sharing into the app lifecycle
  - Checks for URL-encoded match info on startup and loads it if present
  - Added `_tryLoadFromUrl()` method to safely load shared matches with validation (checks bot availability, handles missing data gracefully)
  - Calls `updateUrl()` after loading custom maps to keep URL in sync with current match state
  - Falls back to default startup flow if URL doesn't contain valid match data

- **Updated `MapEditor.js`**: Added `write()` method to programmatically update form fields without triggering change handlers, allowing URL-loaded configs to sync the UI without circular updates

## Implementation Details
- URL parameters are optional except width/height, which anchor the load
- Missing or invalid parameters fall back to sensible defaults (growth: 1.8, maxArmy: 6)
- Bot names are validated against available strategies before loading
- Uses `replaceState` instead of `pushState` to avoid cluttering browser history with each seed change
- Graceful degradation: if a shared link references unknown bots or invalid data, the app logs a warning and loads defaults instead of failing

https://claude.ai/code/session_01VmsWtGPLtq2UA4grvvs3B6