### PR TITLE
Show bot rating on HUD player cards

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -92,6 +92,8 @@ class App {
     // async rankings loader doesn't yank them out of an active view.
     this._userChoseMode = false;
 
+    this.ratings = null;
+
     this.customBots = new CustomBots();
     this.codeModal = new CodeModal();
     this._bindTryBotButton();
@@ -317,6 +319,11 @@ class App {
       console.warn("Couldn't load shared match from URL:", err);
       return false;
     }
+  }
+
+  setRatings(ratings) {
+    this.ratings = ratings;
+    this.hud?.render();
   }
 
   // Snapshot the current match in a form ready for `loadFromMatchInfo` or

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -38,8 +38,13 @@ export class HUD {
     const title = strat?.name ?? player.name ?? "";
     const body = strat?.summary || strat?.description || "";
     const showCodeBtn = !!strat?.name;
+    const rating = this.app?.ratings?.[strat?.name];
+    const ratingHtml = rating != null
+      ? `<div class="strat-tooltip-rating" title="League rating">Rating ${rating}</div>`
+      : "";
     this.tooltip.innerHTML = `
       <div class="strat-tooltip-title">${escapeHtml(title)}</div>
+      ${ratingHtml}
       ${body ? `<div class="strat-tooltip-body">${escapeHtml(body)}</div>` : ""}
       ${renderTechLoadout(player)}
       ${showCodeBtn ? `<button class="btn-mini strat-tooltip-code" data-strat-name="${escapeHtml(strat.name)}">&lt;/&gt; View code</button>` : ""}
@@ -108,9 +113,14 @@ export class HUD {
 
       const head = document.createElement("div");
       head.className = "player-head";
+      const rating = this.app?.ratings?.[player.strategy?.name];
+      const ratingHtml = rating != null
+        ? `<span class="player-rating" title="League rating">${rating}</span>`
+        : "";
       head.innerHTML = `
         <span class="player-dot" style="background:${player.color}"></span>
         <span class="player-name">${escapeHtml(player.name)}</span>
+        ${ratingHtml}
         <span class="player-stat" title="Strength">⬢ <b data-stat="strength">0</b></span>
         <span class="player-stat" title="Territory">▣ <b data-stat="territory">0</b></span>
       `;

--- a/src/ui/LeagueViewer.js
+++ b/src/ui/LeagueViewer.js
@@ -60,6 +60,9 @@ export class LeagueViewer {
     }
     this.rankings = parsed;
     if (this.selection.size === 0) this.applyTier(0);
+    const ratings = {};
+    for (const p of parsed.players) ratings[p.name] = p.rating;
+    this.app?.setRatings?.(ratings);
     this.render();
     this._notifyFirstLoad();
   }

--- a/styles.css
+++ b/styles.css
@@ -333,6 +333,16 @@ select.dropdown {
   letter-spacing: 0.3px;
 }
 
+.strat-tooltip-rating {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-dim);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
 .strat-tooltip-body {
   color: var(--text-dim);
   white-space: pre-wrap;
@@ -469,6 +479,18 @@ select.dropdown {
 .player-name {
   font-weight: 700;
   flex: 1;
+}
+
+.player-rating {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 1px 7px;
+  letter-spacing: 0.3px;
 }
 
 .player-stat {


### PR DESCRIPTION
Plumb tournament/rankings.json data from LeagueViewer through App into
HUD so each player card surfaces its league rating as a pill in the
header, and the strategy hover/pin tooltip shows it as a subtitle. Bots
without a rating (custom paste-ins, ranks-not-yet-loaded) render as
before.