### PR TITLE
Refactor cross-era tournament to generation-based bucketing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tournament/interesting.json
 tournament/matches.jsonl
 tournament/seasons.json
 tournament/loop-run.log
+tournament/exp-lanchester-*.json

--- a/src/core/Army.js
+++ b/src/core/Army.js
@@ -24,9 +24,16 @@ export class Army {
   // still satisfying its player's tech-derived garrison floor. All
   // strategies should reach for attackPower instead of `strength - 1`
   // so the floor scales with the move tech automatically.
+  //
+  // In "budget" movementModel the garrison floor is gone; the engine
+  // only enforces a minimum 0.5 left behind so the source tile doesn't
+  // pop empty mid-tick. Bots can throw more strength forward, but the
+  // per-tile budget will clamp how much actually arrives.
   get attackPower() {
-    const garrison = this.player.minGarrison ?? 1;
-    const v = this.strength - garrison;
+    const floor = this.game?.movementModel === "budget"
+      ? 0.5
+      : (this.player.minGarrison ?? 1);
+    const v = this.strength - floor;
     return v > 0 ? v : 0;
   }
 
@@ -59,7 +66,69 @@ export class Army {
     return true;
   }
 
+  // Wrap-aware Euclidean distance from src to dst, in tiles. Used as
+  // the work multiplier for movement budget in "budget" mode.
+  _distance(src, dst) {
+    const w = this.game.map.width;
+    const h = this.game.map.height;
+    let dx = dst.pos.x - src.pos.x;
+    let dy = dst.pos.y - src.pos.y;
+    if (dx > w / 2) dx -= w; else if (dx < -w / 2) dx += w;
+    if (dy > h / 2) dy -= h; else if (dy < -h / 2) dy += h;
+    return Math.sqrt(dx * dx + dy * dy);
+  }
+
   attack(tile, power) {
+    // Budget movement model: the bot can ask for any (non-self) tile.
+    // The engine computes Euclidean distance, treats power × distance
+    // as work-units, and clamps actual delivered power to whatever
+    // work the source tile's budget can pay for. Adjacent moves
+    // (distance 1) clamp directly against the budget; longer moves
+    // get a smaller effective power for the same budget. Conquest of
+    // the destination resets *its* budget to 0 in resolveConflicts.
+    if (this.game.movementModel === "budget") {
+      if (!tile || this.tile === tile) return false;
+      if (power <= 0.5) return false;
+      const src = this.tile;
+      if (!src) return false;
+      const dist = this._distance(src, tile);
+      if (dist <= 0) return false;
+      const requestedWork = power * dist;
+      const budget = src.budget;
+      const actualWork = requestedWork < budget ? requestedWork : budget;
+      const actualPower = actualWork / dist;
+      if (actualPower <= 0.5) return false;
+      // Engine sanity: keep at least 0.5 strength behind so the
+      // source tile doesn't pop empty mid-tick. Lower bound; the
+      // garrison floor is otherwise gone in budget mode.
+      if (this.strength - actualPower < 0.5) return false;
+      src.budget = budget - actualWork;
+      this.game.recordMove(src, tile, this.player, actualPower);
+      this.strength -= actualPower;
+      const pid = this.player.id;
+      const existing = tile.armies;
+      for (let i = 0; i < existing.length; i++) {
+        const other = existing[i];
+        if (other.alive && other.player.id === pid) {
+          let s = other.strength + actualPower;
+          const max = other.maxStrength;
+          if (s > max) s = max;
+          other.strength = s;
+          return true;
+        }
+      }
+      const newArmy = new Army({
+        pos: tile.pos,
+        player: this.player,
+        strength: actualPower,
+        game: this.game,
+        maxStrength: this.game.maxArmy,
+        tile,
+      });
+      newArmy.isAttacker = true;
+      this.game.spawnArmy(newArmy, tile);
+      return true;
+    }
     if (!this.isAttackValid(tile, power)) return false;
     this.game.recordMove(this.tile, tile, this.player, power);
     this.strength -= power;

--- a/src/core/Army.js
+++ b/src/core/Army.js
@@ -80,12 +80,13 @@ export class Army {
 
   attack(tile, power) {
     // Budget movement model: the bot can ask for any (non-self) tile.
-    // The engine computes Euclidean distance, treats power × distance
-    // as work-units, and clamps actual delivered power to whatever
-    // work the source tile's budget can pay for. Adjacent moves
-    // (distance 1) clamp directly against the budget; longer moves
-    // get a smaller effective power for the same budget. Conquest of
-    // the destination resets *its* budget to 0 in resolveConflicts.
+    // Cost formula has a flat per-move overhead: cost = power *
+    // distance + 1. The +1 is a fixed fee per move regardless of
+    // distance, so many small moves are strictly more expensive
+    // than fewer larger moves carrying the same total power. Engine
+    // clamps actual delivered power to whatever the source tile's
+    // budget can pay for; conquest of the destination resets *its*
+    // budget to 0 in resolveConflicts.
     if (this.game.movementModel === "budget") {
       if (!tile || this.tile === tile) return false;
       if (power <= 0.5) return false;
@@ -93,10 +94,12 @@ export class Army {
       if (!src) return false;
       const dist = this._distance(src, tile);
       if (dist <= 0) return false;
-      const requestedWork = power * dist;
+      // cost = power * distance + 1. Solve actualPower from clamped
+      // actualWork: actualPower = (actualWork - 1) / dist.
+      const requestedWork = power * dist + 1;
       const budget = src.budget;
       const actualWork = requestedWork < budget ? requestedWork : budget;
-      const actualPower = actualWork / dist;
+      const actualPower = (actualWork - 1) / dist;
       if (actualPower <= 0.5) return false;
       // Engine sanity: keep at least 0.5 strength behind so the
       // source tile doesn't pop empty mid-tick. Lower bound; the

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -209,14 +209,23 @@ export class Game {
     // free recharge tick before the new owner has acted.
     if (this.movementModel === "budget") {
       const baseRate = this.baseBudgetRecharge * interval * 30; // tickInterval is 1/30 by default; normalize to ~1 per tick.
-      const cap = this.maxBudget;
+      const baseCap = this.maxBudget;
       const tiles = this.map.tiles;
       for (let i = 0; i < tiles.length; i++) {
         const tile = tiles[i];
         const armies = tile.armies;
         if (armies.length !== 1) continue;
         const owner = armies[0].player;
+        // Move tech multiplies BOTH recharge rate AND budget cap. A
+        // high-move tile fills faster *and* holds more, so the
+        // archetype scales coherently — quick small jabs recover
+        // their work fast, while a saved-up alpha strike can also
+        // be larger. Cap is owner-dependent: when a tile changes
+        // hands, the new ceiling is set by the new owner's tech
+        // (the budget itself was just reset to 0 in resolveConflicts
+        // and will climb to the new cap from there).
         const mult = owner?.techMults?.moveRecharge ?? 1;
+        const cap = baseCap * mult;
         const next = tile.budget + baseRate * mult;
         tile.budget = next > cap ? cap : next;
       }

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -13,6 +13,9 @@ export class Game {
     decay = 0.05,
     attackerBonus = 1.4,
     combatModel = "linear",
+    movementModel = "classic",
+    maxBudget = null,         // budget mode: cap. null -> defaults to maxArmy.
+    baseBudgetRecharge = 1.0, // budget mode: budget gained per tick at neutral move-tech.
     maxHistory = 240,
     seed = null,
   } = {}) {
@@ -37,6 +40,18 @@ export class Game {
     //   not optimal here; the closed-form commit becomes a strict
     //   underestimate.
     this.combatModel = combatModel;
+    // "classic" (default): adjacent-only attacks, garrison floor from
+    //   the move tech. Existing 391 bots target this model.
+    // "budget": tile-local movement budget recharges per tick (scaled
+    //   by the owner's move-tech multiplier), measured in work units
+    //   (strength × Euclidean distance). Attack targets can be any
+    //   tile; the engine clamps actual delivered power so the
+    //   work spent never exceeds the source tile's budget. Conquest
+    //   resets the captured tile's budget to 0, which gives defenders
+    //   a structural tempo advantage and makes blitz raids costly.
+    this.movementModel = movementModel;
+    this.maxBudget = maxBudget != null ? maxBudget : maxArmy;
+    this.baseBudgetRecharge = baseBudgetRecharge;
     this.history = [];
     this.maxHistory = maxHistory;
     this.seed = seed;
@@ -184,6 +199,28 @@ export class Game {
       }
     }
     this.map.resolveConflicts(this._dirtyTiles);
+
+    // Budget mode: each owned tile recharges its movement budget by
+    // baseRecharge × owner.move-tech-multiplier, capped at maxBudget.
+    // Tiles without an army (neutral) are skipped — their budget was
+    // already reset to 0 on whatever conquest left them empty, and
+    // there's no owner to define the recharge rate. Done after combat
+    // resolution so just-conquered tiles (budget=0) don't sneak in a
+    // free recharge tick before the new owner has acted.
+    if (this.movementModel === "budget") {
+      const baseRate = this.baseBudgetRecharge * interval * 30; // tickInterval is 1/30 by default; normalize to ~1 per tick.
+      const cap = this.maxBudget;
+      const tiles = this.map.tiles;
+      for (let i = 0; i < tiles.length; i++) {
+        const tile = tiles[i];
+        const armies = tile.armies;
+        if (armies.length !== 1) continue;
+        const owner = armies[0].player;
+        const mult = owner?.techMults?.moveRecharge ?? 1;
+        const next = tile.budget + baseRate * mult;
+        tile.budget = next > cap ? cap : next;
+      }
+    }
 
     if (this.recentMoves.length > 0) {
       const moves = this.recentMoves;

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -12,6 +12,7 @@ export class Game {
     maxArmy = 6,
     decay = 0.05,
     attackerBonus = 1.4,
+    combatModel = "linear",
     maxHistory = 240,
     seed = null,
   } = {}) {
@@ -26,6 +27,16 @@ export class Game {
     this.maxArmy = maxArmy;
     this.decay = decay;
     this.attackerBonus = attackerBonus;
+    // "linear" (default): winner pays loser_eff/winner_mult raw —
+    //   flat subtractive, no nonlinear reward for overkill.
+    // "lanchester": winner's post-fight effective strength is
+    //   sqrt(winner_eff^2 - loser_eff^2). Concentration of force
+    //   compounds — a 2x force ratio is ~4x more efficient — so
+    //   shaping mass at the breakthrough pays directly. Bots tuned
+    //   on linear (Conqueror's enemy/1.4 + MARGIN commit math) are
+    //   not optimal here; the closed-form commit becomes a strict
+    //   underestimate.
+    this.combatModel = combatModel;
     this.history = [];
     this.maxHistory = maxHistory;
     this.seed = seed;

--- a/src/core/Tech.js
+++ b/src/core/Tech.js
@@ -82,21 +82,32 @@ export function validateTech(tech) {
   return t;
 }
 
+// Movement-budget recharge multiplier in "budget" movementModel.
+// Pivots at 1.0 at tech 20 (neutral), reaches 0.6 at tech 0 and 2.6
+// at tech 100. Same shape as the other knobs (linear with `1.0 +
+// (tech - 20) * MOVE_RECHARGE_SLOPE`); decoupled from SLOPES.move
+// because the classic-mode formula has different units (garrison
+// floor in strength, not a multiplier).
+const MOVE_RECHARGE_SLOPE = 0.020;
+
 export function techToMultipliers(tech) {
   const t = validateTech(tech);
   const mults = {};
   for (const k of KNOBS) {
     if (k === "move") {
-      // Move's "multiplier" is the garrison floor; high tech reduces
-      // the floor so the bot can throw more strength forward. Linear
-      // from MOVE_INTERCEPT (1.5) at tech 0 to MOVE_INTERCEPT - 100 *
-      // SLOPES.move (0.5) at tech 100. No clamp - the formula is the
-      // contract.
+      // Classic movementModel: move multiplier *is* the garrison
+      // floor. Linear from MOVE_INTERCEPT (1.5) at tech 0 to
+      // MOVE_INTERCEPT - 100 * SLOPES.move (0.5) at tech 100. No
+      // clamp - the formula is the contract.
       mults[k] = MOVE_INTERCEPT - t[k] * SLOPES[k];
     } else {
       mults[k] = 1.0 + (t[k] - BASELINE) * SLOPES[k];
     }
   }
+  // Budget movementModel: separate per-tile recharge multiplier
+  // computed from the same move tech value but on a clean 1.0-pivot
+  // shape so it composes naturally with the other knobs.
+  mults.moveRecharge = 1.0 + (t.move - BASELINE) * MOVE_RECHARGE_SLOPE;
   return mults;
 }
 

--- a/src/core/Tile.js
+++ b/src/core/Tile.js
@@ -61,21 +61,32 @@ export class Tile {
       }
     }
 
-    // Risk-style: attackers fight with bonus effective strength, so even
-    // a slightly-smaller attacker can dislodge a defender, and a
+    // Risk-style: attackers fight with bonus effective strength, so
+    // even a slightly-smaller attacker can dislodge a defender, and a
     // larger attacker keeps more troops after a successful conquest.
     // Per-player tech further multiplies: atkMult on attackers,
-    // defMult on defenders. realLoss inverts whichever multiplier the
-    // *winning* side carried, since effLoss is in effective-strength
-    // units.
-    const bonus = (grouped[0] && grouped[0].game && grouped[0].game.attackerBonus) || 1;
+    // defMult on defenders.
+    //
+    // Two combat models, switched at the Game level:
+    //   linear (default): winner's post-fight raw strength is
+    //     (wE - lE) / wMult — flat subtractive, overkill earns
+    //     nothing nonlinear, equal effective forces annihilate.
+    //   lanchester: winner's post-fight effective strength is
+    //     sqrt(wE^2 - lE^2). A 2x ratio is ~4x more efficient than
+    //     a 1.01x ratio, so concentrating mass at a breakthrough
+    //     pays compounding dividends. Bots tuned on linear (e.g.
+    //     Conqueror's enemy/1.4 + MARGIN commit math) under-commit
+    //     here — closed-form min-overkill becomes a strict
+    //     underestimate of the right attack size.
+    const game = grouped[0] && grouped[0].game;
+    const bonus = (game && game.attackerBonus) || 1;
+    const model = (game && game.combatModel) || "linear";
     const armyMult = (army) => {
       const m = army.player.techMults;
       if (army.isAttacker) return bonus * (m ? m.atk : 1);
       return m ? m.def : 1;
     };
     const eff = (army) => army.strength * armyMult(army);
-    const realLoss = (army, effLoss) => effLoss / armyMult(army);
 
     let survivor = null;
     for (let i = 0; i < grouped.length; i++) {
@@ -87,17 +98,21 @@ export class Tile {
       }
       const aE = eff(army);
       const sE = eff(survivor);
-      if (aE > sE) {
-        army.strength -= realLoss(army, sE);
-        if (army.strength < 0.5) army.die();
-        survivor.die();
-        survivor = army.alive ? army : null;
+      const winner = aE >= sE ? army : survivor;
+      const loser = aE >= sE ? survivor : army;
+      const wE = aE >= sE ? aE : sE;
+      const lE = aE >= sE ? sE : aE;
+      let postRaw;
+      if (model === "lanchester") {
+        const sq = wE * wE - lE * lE;
+        postRaw = sq > 0 ? Math.sqrt(sq) / armyMult(winner) : 0;
       } else {
-        survivor.strength -= realLoss(survivor, aE);
-        if (survivor.strength < 0.5) survivor.die();
-        army.die();
-        if (!survivor.alive) survivor = null;
+        postRaw = wE > lE ? (wE - lE) / armyMult(winner) : 0;
       }
+      winner.strength = postRaw;
+      if (winner.strength < 0.5) winner.die();
+      loser.die();
+      survivor = winner.alive ? winner : null;
     }
 
     if (survivor && survivor.alive) {

--- a/src/core/Tile.js
+++ b/src/core/Tile.js
@@ -10,6 +10,12 @@ export class Tile {
     this.ownership = 0;
     this.ownerId = 0;
     this.dirty = false;
+    // Per-tile movement budget in work units (strength × distance).
+    // Recharges per tick (modulated by owner's move-tech multiplier),
+    // is clamped on use (min of requested work and available budget),
+    // and resets to 0 when the tile changes hands. Only consulted in
+    // "budget" movement mode; classic mode ignores it.
+    this.budget = 0;
   }
 
   registerArmy(army) {
@@ -38,10 +44,15 @@ export class Tile {
 
     const grouped = [];
     const groupedPids = [];
+    // Identify the previous holder (army that was already on the tile,
+    // not arrived this tick) for conquest detection. If no
+    // non-attacker is present the tile was effectively neutral.
+    let prevHolderPid = null;
     for (let k = 0; k < list.length; k++) {
       const a = list[k];
       if (!a.alive) continue;
       const pid = a.player.id;
+      if (!a.isAttacker && prevHolderPid === null) prevHolderPid = pid;
       let merged = false;
       for (let g = 0; g < groupedPids.length; g++) {
         if (groupedPids[g] === pid) {
@@ -114,6 +125,12 @@ export class Tile {
       loser.die();
       survivor = winner.alive ? winner : null;
     }
+
+    // Conquest reset: if ownership of the tile changes (or the tile
+    // empties out entirely), zero the per-tile movement budget. Only
+    // meaningful in "budget" movement mode; otherwise it's a no-op.
+    const newPid = survivor && survivor.alive ? survivor.player.id : null;
+    if (newPid !== prevHolderPid) this.budget = 0;
 
     if (survivor && survivor.alive) {
       survivor.isAttacker = false;

--- a/src/strategies/Drumline.js
+++ b/src/strategies/Drumline.js
@@ -1,0 +1,245 @@
+import { sumStrength } from "../core/Army.js";
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+const MARGIN = 0.45;
+const BACKING_WEIGHT = 0.4;
+const RETAKE_W = 0.8;
+const FRIENDLY_W = 0.4;
+const RETAKE_VETO = 1.5;
+// Phase length: how many ticks the wave direction stays committed
+// before recomputation. Pinwheel's PHASE_TICKS=4 lets a single push
+// propagate two tiles deep before redirecting; same value here.
+const PHASE_TICKS = 4;
+// Wave bonus added to a kill candidate's score when its direction
+// matches the wave. Calibrated to be ~half a typical strength unit:
+// it tiebreaks among comparable kills (e.g. a 1.0-strength target
+// in the wave dir vs a 1.0 target perpendicular) without overriding
+// genuinely better kills (a 2.0-strength target in a perpendicular
+// direction still wins on enemy + backing).
+const WAVE_BONUS = 0.5;
+
+const HEMI = (() => {
+  const w = [], e = [], n = [], s = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const idx = i * 5 + j;
+      const dx = j - 2;
+      const dy = i - 2;
+      if (dx < 0) w.push(idx);
+      if (dx > 0) e.push(idx);
+      if (dy < 0) n.push(idx);
+      if (dy > 0) s.push(idx);
+    }
+  }
+  return [w, e, n, s];
+})();
+
+function getWaveDir(game, viewer) {
+  const cache = game._drumlineCache || (game._drumlineCache = new Map());
+  const slot = cache.get(viewer.id);
+  if (slot && game.tick - slot.phaseStart < PHASE_TICKS) return slot.dir;
+  const dir = computeWaveDir(game, viewer);
+  cache.set(viewer.id, { phaseStart: game.tick, dir });
+  return dir;
+}
+
+function computeWaveDir(game, viewer) {
+  const armies = game.armies;
+  const w = game.map.width;
+  const h = game.map.height;
+  const players = game.players.list;
+  const cents = new Map();
+  for (let i = 0; i < players.length; i++) {
+    const p = players[i];
+    if (!p.totals || (p.totals.armies | 0) === 0) continue;
+    cents.set(p.id, { anchor: null, wx: 0, wy: 0, sum: 0 });
+  }
+  if (!cents.has(viewer.id)) return -1;
+  for (let i = 0; i < armies.length; i++) {
+    const a = armies[i];
+    if (!a.alive) continue;
+    const c = cents.get(a.player.id);
+    if (!c) continue;
+    if (!c.anchor) c.anchor = a.pos;
+    let dx = a.pos.x - c.anchor.x;
+    let dy = a.pos.y - c.anchor.y;
+    if (dx > w / 2) dx -= w; else if (dx < -w / 2) dx += w;
+    if (dy > h / 2) dy -= h; else if (dy < -h / 2) dy += h;
+    c.wx += dx * a.strength;
+    c.wy += dy * a.strength;
+    c.sum += a.strength;
+  }
+  const me = cents.get(viewer.id);
+  if (!me || me.sum === 0) return -1;
+  const myCx = me.anchor.x + me.wx / me.sum;
+  const myCy = me.anchor.y + me.wy / me.sum;
+  let target = null;
+  let bestD2 = Infinity;
+  for (const [pid, c] of cents.entries()) {
+    if (pid === viewer.id) continue;
+    if (c.sum === 0) continue;
+    const cx = c.anchor.x + c.wx / c.sum;
+    const cy = c.anchor.y + c.wy / c.sum;
+    let dx = cx - myCx, dy = cy - myCy;
+    if (dx > w / 2) dx -= w; else if (dx < -w / 2) dx += w;
+    if (dy > h / 2) dy -= h; else if (dy < -h / 2) dy += h;
+    const d2 = dx * dx + dy * dy;
+    if (d2 < bestD2) { bestD2 = d2; target = { dx, dy }; }
+  }
+  if (!target) return -1;
+  if (Math.abs(target.dx) < 0.5 && Math.abs(target.dy) < 0.5) return -1;
+  if (Math.abs(target.dx) >= Math.abs(target.dy)) return target.dx < 0 ? 0 : 1;
+  return target.dy < 0 ? 2 : 3;
+}
+
+export default {
+  name: "Drumline",
+  author: "claude",
+  version: 1,
+  description:
+    "Conqueror_g13's chassis with the wave injected as a kill-pick tiebreaker: among similarly-scored adjacent kills, prefer the one in the closest opponent's direction so frontier armies converge into a coordinated push.",
+  summary: `Cross-era data showed that Pinwheel — a primitive
+fixed-rotation sync bot from g0 — still beats the lineage's current
+champion 33% of the time pairwise. Wave compounding is real but
+hard to graft onto Conqueror's chassis. Three earlier Drumline
+drafts failed instructively:
+
+  v1 mixed wave bias into the kill score uniformly — kills always
+  outranked the bias, so the wave never fired (final 34.9%).
+  v2 tried wave first and fell through — gave away every adjacent
+  kill, lost the field 25.7%.
+  v3 used wave only on non-kill ticks — Conqueror's stencil kernel
+  is already a smarter non-kill picker than a global cardinal,
+  losing 28.9%.
+
+The lesson: replacing any of Conqueror's decisions with a less-
+informed wave is strictly worse. The wave can only help where it
+breaks ties Conqueror's kernel doesn't already handle: among
+similarly-scored adjacent kills.
+
+Mechanism: this version inlines Conqueror_g13_b41df9's Pass 1
+hemisphere/territory kill picker and adds a small WAVE_BONUS=0.5
+to the score when the candidate kill is in the wave direction.
+That's about half a strength unit — enough to tiebreak among
+comparable kills (1.0-strength target in wave dir vs 1.0
+perpendicular) but small enough that a genuinely-better kill (2.0
+strength on a different direction with strong backing) still
+wins. Pass 2 (no kill, has expand/reinforce target) and Pass 3
+(stencil-based stalemate) defer entirely to the parent chassis,
+which handles those cases cleanly without a wave term.
+
+The wave direction is the cardinal of (closest live opponent's
+centroid - our centroid) on the wrap-aware torus, recomputed at
+every PHASE_TICKS=4 boundary. Closest, not strongest: the wave
+only compounds when there's a real frontier in front of it,
+which by definition lives between us and our nearest neighbor.
+
+Tech mirrors g20_43253a's cross-era champion loadout
+{move:76, stack:0, prod:16, atk:5, def:3} so the comparison
+isolates the strategic delta — wave-aware kill tiebreaks — from
+the tech optimization the lineage has spent 20 generations on.
+
+If this still loses to the parent, the conclusion is that
+Conqueror's kill scorer is calibrated tightly enough that even a
+0.5 wave bonus distorts more pairs than it tiebreaks usefully —
+the lineage has already converged onto a kill ordering that
+implicitly captures coordination. In that case the next iteration
+should either drop WAVE_BONUS toward 0.2, or pivot to a different
+axis entirely (e.g. pre-emptive retreat of soon-to-die armies via
+attacking backwards into a friendly with room).`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) {
+      Conqueror.act(army, game);
+      return;
+    }
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+    const waveDir = getWaveDir(game, viewer);
+
+    let bestKill = null;
+    let bestScore = -Infinity;
+    let bestNeeded = 0;
+    let hasOtherTarget = false;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) { hasOtherTarget = true; continue; }
+      let friendlyArmy = null;
+      let enemy = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
+      }
+      if (enemy > 0) {
+        const needed = enemy / BONUS + MARGIN;
+        if (needed > sLimit) continue;
+
+        let backup = 0;
+        let friend = 0;
+        const tn = t.neighbors;
+        for (let j = 0; j < 4; j++) {
+          const tt = tn[j];
+          if (!tt || tt === tile) continue;
+          const ttArmies = tt.armies;
+          let tnE = 0;
+          let tnF = 0;
+          for (let k = 0; k < ttArmies.length; k++) {
+            const a = ttArmies[k];
+            if (a.player.id === pid) tnF += a.strength;
+            else tnE += a.strength;
+          }
+          if (tnE > backup) backup = tnE;
+          if (tnF > friend) friend = tnF;
+        }
+        if (backup >= RETAKE_VETO) continue;
+
+        let backing = 0;
+        if (stencil) {
+          const idxs = HEMI[i];
+          for (let k = 0; k < idxs.length; k++) {
+            const cell = stencil[idxs[k]];
+            if (!cell) continue;
+            const cArmies = cell.armies;
+            if (cArmies.length === 0) continue;
+            const e = -sumStrength(cArmies, viewer);
+            if (e > 0) backing += e;
+          }
+        }
+
+        let score = enemy
+          + BACKING_WEIGHT * backing
+          - RETAKE_W * backup
+          + FRIENDLY_W * friend;
+        if (i === waveDir) score += WAVE_BONUS;
+        if (score > bestScore) {
+          bestScore = score;
+          bestNeeded = needed;
+          bestKill = t;
+        }
+        continue;
+      }
+      if (friendlyArmy && friendlyArmy.strength < friendlyArmy.maxStrength - 0.5) {
+        hasOtherTarget = true;
+      }
+    }
+    if (bestKill) {
+      army.attack(bestKill, bestNeeded);
+      return;
+    }
+
+    // No kill on the table. Defer entirely to Conqueror's kernel-based
+    // non-kill logic — it picks expansion/reinforcement targets via
+    // 5x5 alignment scoring, which is consistently better than a
+    // global cardinal in this lineage's match data.
+    Conqueror.act(army, game);
+  },
+};

--- a/src/strategies/Hammer.js
+++ b/src/strategies/Hammer.js
@@ -1,119 +1,167 @@
+import { sumStrength } from "../core/Army.js";
+import Parent from "./Conqueror_g13_b41df9.js";
 import Conqueror from "./Conqueror.js";
 
 const BONUS = 1.4;
+const MARGIN = 0.45;
+const BACKING_WEIGHT = 0.4;
+const RETAKE_W = 0.8;
+const FRIENDLY_W = 0.4;
+const RETAKE_VETO = 1.5;
+
+// Same chassis as Conqueror_g13_b41df9 with one change in Pass 1:
+// instead of committing the closed-form min-overkill (enemy/BONUS +
+// MARGIN), commit the army's full attackPower clamped by the
+// engine's budget rule. Under Lanchester combat the surplus is
+// preserved as raw strength on the captured tile (sqrt(W^2 - L^2)
+// >> W - L for W >> L), and under cost = power*dist+1 the +1
+// overhead is paid once whether we send 1.5 or 8 strength — so
+// max-commit is strictly more efficient per move.
+const HEMI = (() => {
+  const w = [], e = [], n = [], s = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const idx = i * 5 + j;
+      const dx = j - 2;
+      const dy = i - 2;
+      if (dx < 0) w.push(idx);
+      if (dx > 0) e.push(idx);
+      if (dy < 0) n.push(idx);
+      if (dy > 0) s.push(idx);
+    }
+  }
+  return [w, e, n, s];
+})();
 
 export default {
   name: "Hammer",
   author: "claude",
   version: 1,
   description:
-    "Adjacent-only over-commit: pick the strongest beatable enemy and dump max attackPower (clamped by budget) instead of Conqueror's minimum-overkill formula. Lanchester rewards the surplus.",
-  summary: `Conqueror's chassis commits exactly enemy/1.4 + 0.5
-strength to a kill — calibrated for linear combat, where overkill
-earns nothing. Under combatModel="lanchester" that formula becomes
-a strict under-commit: post-fight survivor effective strength is
-sqrt(W^2 - L^2), so a 2x ratio is ~4x more efficient than 1.01x.
-Min-overkill leaves the survivor at ~0 strength, then the
-budget-clamping in budget mode means even that survivor is
-underfunded for follow-up moves.
+    "Conqueror_g13 chassis with Pass 1 max-commit: pick the best adjacent kill via hemisphere/territory scoring, then commit attackPower (engine clamps to budget). Lanchester preserves the surplus; cost-formula's +1 overhead is paid once per move regardless of size.",
+  summary: `Conqueror's chassis under linear+classic was tuned to
+commit exactly enemy/1.4 + 0.45 — saves strength for the next
+tick. Under combatModel="lanchester" + cost = power*dist+1, that
+calculus inverts:
 
-Hammer ignores the closed-form commit math entirely. For each
-adjacent direction it picks the best beatable enemy by enemy
-strength + a small backing/territory bonus, then fires
-attackPower (full available, clamped automatically by the engine
-to budget). Under Lanchester this is rarely wasteful: any
-"overkill" returns as more raw strength preserved on the
-captured tile. Under budget mode, sending more than the budget
-allows is a no-op (engine clamps), so there's no downside to
-asking for max.
+  - Lanchester: sqrt(W^2 - L^2) preserves vastly more strength
+    when W >> L. The surplus you commit comes back as raw post-
+    fight strength on the captured tile, ready for follow-up.
+  - Cost formula: each move pays +1 overhead. Sending 1.5 power
+    costs 2.5; sending 8 power costs 9. Per delivered strength,
+    the big move is much cheaper.
 
-Per army:
-  1. Scan 4 neighbors for any beatable enemy. Beatable =
-     attackPower * atkMult * BONUS > enemy_strength * 1.05 (small
-     safety margin against Lanchester near-tie annihilation).
-  2. Among beatable enemies, pick the one with the highest
-     (enemy_strength + 0.4 * adjacent_friendly_strength) — kills
-     a bigger threat with more friendly support, mirroring
-     Conqueror's hemisphere bias but without the kernel cost.
-  3. Commit attackPower (the engine's budget clamp does the rest).
-  4. No beatable adjacent enemy: fall through to Conqueror.act
-     for stencil-based moves.
+Hammer keeps Conqueror_g13's Pass 1 kill scorer (hemisphere
+backing + territory friendly weight + retake veto) to pick the
+best target, but commits the army's full attackPower instead of
+min-overkill. The engine clamps to budget automatically, so on
+low-budget ticks Hammer behaves like the chassis; on full-budget
+ticks Hammer dumps decisively and the captured tile lands with
+much more raw strength left over.
 
-Tech is brutally offensive: {move:30, stack:0, prod:20, atk:40,
-def:10}. atk:40 is much higher than the lineage's typical 4-5
-because Lanchester rewards atk multiplicatively in the ratio:
-high atk means our effective W is much larger than the
-defender's L, and sqrt(W^2 - L^2) approaches W — we keep almost
-all our raw strength after winning. move:30 (1.2x recharge +
-1.2x cap) is enough for adjacent-only play. prod:20 keeps
-strength replenishing. def:10 buys some durability on the rare
-tick we can't kill first.
+Pass 2 (no kill, has expand/reinforce target) and Pass 3 (stencil
+stalemate) are inherited unchanged from Parent — they're not the
+locus of the over-commit thesis and the chassis already handles
+those cases well.
 
-Expected to crush bots that under-commit (every classic-tuned
-Conqueror). Expected to lose to other over-commit bots whose
-strength regen keeps up better, or to ranged bots (Sniper) that
-exploit Hammer's adjacent-only horizon.`,
-  tech: { move: 60, stack: 0, prod: 10, atk: 20, def: 10 },
+Tech mirrors g14_8d5369's validated chassis loadout {move:76,
+stack:0, prod:16, atk:5, def:3} so the comparison isolates the
+strategic delta — max-commit on Pass 1 — from any tech tuning.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;
     const sLimit = army.attackPower;
-    if (sLimit <= 0.5) return;
+    if (sLimit <= 0.5) {
+      Conqueror.act(army, game);
+      return;
+    }
     const neighbors = tile.neighbors;
     const pid = army.player.id;
-    const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
-    const myEff = sLimit * atkMult;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
 
     let bestKill = null;
     let bestScore = -Infinity;
+    let hasOtherTarget = false;
     for (let i = 0; i < 4; i++) {
       const t = neighbors[i];
       if (!t) continue;
-      const tArmies = t.armies;
-      if (tArmies.length === 0) continue;
-      let friendly = false;
+      const armies = t.armies;
+      if (armies.length === 0) { hasOtherTarget = true; continue; }
+      let friendlyArmy = null;
       let enemy = 0;
-      for (let k = 0; k < tArmies.length; k++) {
-        const a = tArmies[k];
-        if (a.player.id === pid) { friendly = true; break; }
-        enemy += a.strength;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
       }
-      if (friendly) continue;
-      // Need to overwhelm with margin under Lanchester: if myEff is
-      // only slightly above enemy, sqrt(myEff^2 - enemy^2) ~ 0 and
-      // we trade for nothing. 1.05x margin avoids the near-tie
-      // annihilation zone.
-      if (myEff <= enemy * 1.05) continue;
+      if (enemy > 0) {
+        // Beatable check stays at min-overkill — we still need
+        // sLimit >= the bare-minimum to win. We just don't commit
+        // only that minimum.
+        const needed = enemy / BONUS + MARGIN;
+        if (needed > sLimit) continue;
 
-      // Backing bias: prefer kills supported by adjacent friendly
-      // strength on neighbors of the target.
-      let backing = 0;
-      const tn = t.neighbors;
-      for (let j = 0; j < 4; j++) {
-        const nt = tn[j];
-        if (!nt || nt === tile) continue;
-        const ntArmies = nt.armies;
-        for (let k = 0; k < ntArmies.length; k++) {
-          const a = ntArmies[k];
-          if (a.player.id === pid) backing += a.strength;
+        let backup = 0;
+        let friend = 0;
+        const tn = t.neighbors;
+        for (let j = 0; j < 4; j++) {
+          const tt = tn[j];
+          if (!tt || tt === tile) continue;
+          const ttArmies = tt.armies;
+          let tnE = 0, tnF = 0;
+          for (let k = 0; k < ttArmies.length; k++) {
+            const a = ttArmies[k];
+            if (a.player.id === pid) tnF += a.strength;
+            else tnE += a.strength;
+          }
+          if (tnE > backup) backup = tnE;
+          if (tnF > friend) friend = tnF;
         }
-      }
+        if (backup >= RETAKE_VETO) continue;
 
-      const score = enemy + 0.4 * backing;
-      if (score > bestScore) {
-        bestScore = score;
-        bestKill = t;
+        let backing = 0;
+        if (stencil) {
+          const idxs = HEMI[i];
+          for (let k = 0; k < idxs.length; k++) {
+            const cell = stencil[idxs[k]];
+            if (!cell) continue;
+            const cArmies = cell.armies;
+            if (cArmies.length === 0) continue;
+            const e = -sumStrength(cArmies, viewer);
+            if (e > 0) backing += e;
+          }
+        }
+        const score = enemy
+          + BACKING_WEIGHT * backing
+          - RETAKE_W * backup
+          + FRIENDLY_W * friend;
+        if (score > bestScore) {
+          bestScore = score;
+          bestKill = t;
+        }
+        continue;
+      }
+      if (friendlyArmy && friendlyArmy.strength < friendlyArmy.maxStrength - 0.5) {
+        hasOtherTarget = true;
       }
     }
 
     if (bestKill) {
-      // Commit max — engine clamps to budget. Lanchester preserves
-      // surplus as raw strength on the captured tile.
+      // Max commit instead of min-overkill. Engine clamps to
+      // budget; Lanchester preserves the surplus.
       army.attack(bestKill, sLimit);
       return;
     }
 
-    // No beatable adjacent enemy — defer for stencil expansion.
-    Conqueror.act(army, game);
+    // No adjacent kill — defer to chassis for stencil-based moves
+    // and reinforcements. The chassis handles those cases well;
+    // the over-commit thesis only applies to kills.
+    if (hasOtherTarget) {
+      Conqueror.act(army, game);
+      return;
+    }
+    Parent.act(army, game);
   },
 };

--- a/src/strategies/Hammer.js
+++ b/src/strategies/Hammer.js
@@ -53,7 +53,7 @@ Expected to crush bots that under-commit (every classic-tuned
 Conqueror). Expected to lose to other over-commit bots whose
 strength regen keeps up better, or to ranged bots (Sniper) that
 exploit Hammer's adjacent-only horizon.`,
-  tech: { move: 30, stack: 0, prod: 20, atk: 40, def: 10 },
+  tech: { move: 60, stack: 0, prod: 10, atk: 20, def: 10 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;

--- a/src/strategies/Hammer.js
+++ b/src/strategies/Hammer.js
@@ -1,0 +1,119 @@
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+
+export default {
+  name: "Hammer",
+  author: "claude",
+  version: 1,
+  description:
+    "Adjacent-only over-commit: pick the strongest beatable enemy and dump max attackPower (clamped by budget) instead of Conqueror's minimum-overkill formula. Lanchester rewards the surplus.",
+  summary: `Conqueror's chassis commits exactly enemy/1.4 + 0.5
+strength to a kill — calibrated for linear combat, where overkill
+earns nothing. Under combatModel="lanchester" that formula becomes
+a strict under-commit: post-fight survivor effective strength is
+sqrt(W^2 - L^2), so a 2x ratio is ~4x more efficient than 1.01x.
+Min-overkill leaves the survivor at ~0 strength, then the
+budget-clamping in budget mode means even that survivor is
+underfunded for follow-up moves.
+
+Hammer ignores the closed-form commit math entirely. For each
+adjacent direction it picks the best beatable enemy by enemy
+strength + a small backing/territory bonus, then fires
+attackPower (full available, clamped automatically by the engine
+to budget). Under Lanchester this is rarely wasteful: any
+"overkill" returns as more raw strength preserved on the
+captured tile. Under budget mode, sending more than the budget
+allows is a no-op (engine clamps), so there's no downside to
+asking for max.
+
+Per army:
+  1. Scan 4 neighbors for any beatable enemy. Beatable =
+     attackPower * atkMult * BONUS > enemy_strength * 1.05 (small
+     safety margin against Lanchester near-tie annihilation).
+  2. Among beatable enemies, pick the one with the highest
+     (enemy_strength + 0.4 * adjacent_friendly_strength) — kills
+     a bigger threat with more friendly support, mirroring
+     Conqueror's hemisphere bias but without the kernel cost.
+  3. Commit attackPower (the engine's budget clamp does the rest).
+  4. No beatable adjacent enemy: fall through to Conqueror.act
+     for stencil-based moves.
+
+Tech is brutally offensive: {move:30, stack:0, prod:20, atk:40,
+def:10}. atk:40 is much higher than the lineage's typical 4-5
+because Lanchester rewards atk multiplicatively in the ratio:
+high atk means our effective W is much larger than the
+defender's L, and sqrt(W^2 - L^2) approaches W — we keep almost
+all our raw strength after winning. move:30 (1.2x recharge +
+1.2x cap) is enough for adjacent-only play. prod:20 keeps
+strength replenishing. def:10 buys some durability on the rare
+tick we can't kill first.
+
+Expected to crush bots that under-commit (every classic-tuned
+Conqueror). Expected to lose to other over-commit bots whose
+strength regen keeps up better, or to ranged bots (Sniper) that
+exploit Hammer's adjacent-only horizon.`,
+  tech: { move: 30, stack: 0, prod: 20, atk: 40, def: 10 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
+    const myEff = sLimit * atkMult;
+
+    let bestKill = null;
+    let bestScore = -Infinity;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const tArmies = t.armies;
+      if (tArmies.length === 0) continue;
+      let friendly = false;
+      let enemy = 0;
+      for (let k = 0; k < tArmies.length; k++) {
+        const a = tArmies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) continue;
+      // Need to overwhelm with margin under Lanchester: if myEff is
+      // only slightly above enemy, sqrt(myEff^2 - enemy^2) ~ 0 and
+      // we trade for nothing. 1.05x margin avoids the near-tie
+      // annihilation zone.
+      if (myEff <= enemy * 1.05) continue;
+
+      // Backing bias: prefer kills supported by adjacent friendly
+      // strength on neighbors of the target.
+      let backing = 0;
+      const tn = t.neighbors;
+      for (let j = 0; j < 4; j++) {
+        const nt = tn[j];
+        if (!nt || nt === tile) continue;
+        const ntArmies = nt.armies;
+        for (let k = 0; k < ntArmies.length; k++) {
+          const a = ntArmies[k];
+          if (a.player.id === pid) backing += a.strength;
+        }
+      }
+
+      const score = enemy + 0.4 * backing;
+      if (score > bestScore) {
+        bestScore = score;
+        bestKill = t;
+      }
+    }
+
+    if (bestKill) {
+      // Commit max — engine clamps to budget. Lanchester preserves
+      // surplus as raw strength on the captured tile.
+      army.attack(bestKill, sLimit);
+      return;
+    }
+
+    // No beatable adjacent enemy — defer for stencil expansion.
+    Conqueror.act(army, game);
+  },
+};

--- a/src/strategies/Reservoir.js
+++ b/src/strategies/Reservoir.js
@@ -1,0 +1,72 @@
+import Parent from "./Conqueror_g13_b41df9.js";
+
+const BONUS = 1.4;
+
+// Detect tiles where the chassis would otherwise produce a
+// "wasted" tick — defined as: no enemy adjacent, no empty
+// neighbor, and at least one friendly neighbor at or near maxStrength
+// (which the chassis fallback would attempt to reinforce, paying
+// +1 move overhead for ~zero strength delivered).
+function isWastedTick(tile, pid) {
+  const n = tile.neighbors;
+  let hasMaxedFriendly = false;
+  for (let i = 0; i < 4; i++) {
+    const t = n[i];
+    if (!t) continue;
+    const armies = t.armies;
+    if (armies.length === 0) return false; // empty = real action
+    for (let k = 0; k < armies.length; k++) {
+      const a = armies[k];
+      if (a.player.id !== pid) return false; // enemy = real action
+      if (a.strength >= a.maxStrength - 0.5) hasMaxedFriendly = true;
+    }
+  }
+  return hasMaxedFriendly;
+}
+
+export default {
+  name: "Reservoir",
+  author: "claude",
+  version: 1,
+  description:
+    "Conqueror_g13 chassis with one strict upgrade: idle on interior ticks where the chassis would otherwise reinforce a maxed friendly (paying the +1 move overhead for ~zero delivered strength). Chassis runs verbatim everywhere else.",
+  summary: `Cost formula on this ruleset is power * distance + 1.
+The chassis's Pass 3 stencil fallback occasionally walks the
+army into a "reinforce a maxed friendly" move — the engine clamps
+the actual delivered strength to the friendly's remaining room
+(near zero), but the +1 move overhead is still paid in full.
+Multiplied across many tiles and many ticks, that overhead is
+real budget loss.
+
+Reservoir's only change: detect this exact case before invoking
+the chassis. If the tile has no empty neighbor, no enemy
+neighbor, and at least one maxed friendly neighbor, idle
+instead of acting. The chassis would have done something
+near-useless on this tick; idling saves the +1 overhead and
+lets the tile's strength + budget continue to accumulate for a
+future tick where a real opportunity appears.
+
+In every other case (any enemy adjacent, any empty neighbor,
+chassis Pass 1/2 finds a real kill or expansion), defer to the
+chassis verbatim. Reservoir is at minimum chassis-equivalent
+and strictly better on the wasted-reinforce ticks the chassis
+otherwise burns.
+
+Tech mirrors g14_8d5369's chassis loadout {move:76, stack:0,
+prod:16, atk:5, def:3}. The idle behavior is pure addition.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) {
+      Parent.act(army, game);
+      return;
+    }
+    const pid = army.player.id;
+
+    if (isWastedTick(tile, pid)) return;
+
+    Parent.act(army, game);
+  },
+};

--- a/src/strategies/Sniper.js
+++ b/src/strategies/Sniper.js
@@ -114,8 +114,10 @@ mirror or to other ranged bots that can counter-snipe.`,
         // arrivals.
         const minPower = Math.sqrt(1.0 + (enemy / atkMult) ** 2) * 1.1;
         // Cap by all three constraints: budget at this distance, the
-        // army's keep-half-home rule, and the army's strength.
-        const maxPowerByBudget = workCap / dist;
+        // army's keep-half-home rule, and the army's strength. Cost
+        // formula is power * distance + 1, so max deliverable power
+        // at this distance is (workCap - 1) / dist.
+        const maxPowerByBudget = (workCap - 1) / dist;
         const ceiling = Math.min(maxPowerByBudget, maxSelfCommit, sLimit);
         if (minPower > ceiling) continue;
 

--- a/src/strategies/Sniper.js
+++ b/src/strategies/Sniper.js
@@ -1,0 +1,126 @@
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+// Don't burn the entire budget in one shot — leave headroom so we
+// can act again next tick if a better target appears. 0.7 means each
+// snipe spends at most 70% of available budget.
+const BUDGET_FRACTION = 0.7;
+// Search radius for vulnerable enemy tiles. 5 covers most of lab1's
+// 30x22 board within a reasonable scan, and the budget cap (12 *
+// moveRecharge) limits useful range anyway.
+const RADIUS = 5;
+
+export default {
+  name: "Sniper",
+  author: "claude",
+  version: 1,
+  description:
+    "Long-range teleport bot: each tick scans a 5-tile radius for a vulnerable enemy tile, then teleports decisive force from this army's home tile to land a decisive Lanchester kill.",
+  summary: `New ruleset (movementModel="budget", combatModel="lanchester")
+unlocks a strategy no Conqueror cousin can replicate: ranged
+teleport at non-adjacent targets. Sniper exploits this directly.
+
+Per-army logic:
+  1. Scan tiles within RADIUS=5 (Euclidean) for an enemy tile that
+     this army can kill cleanly. The cost in work units (power x
+     distance) is capped at BUDGET_FRACTION * tile.budget so we
+     keep some recharge headroom for next tick.
+  2. Among kill candidates, pick the one that maximizes
+     (enemy_strength - 0.3 * distance) — score weights big targets
+     higher and slightly penalizes far shots (more costly for the
+     same delivered power).
+  3. If the candidate's required commit (under Lanchester: enough
+     to win cleanly given atk * BONUS attacker multiplier) fits in
+     the budget-fraction work cap, teleport and return.
+  4. Otherwise, fall through to Conqueror.act for local adjacent
+     action — the chassis handles routine kills/expansion well.
+
+Tech is offense-leaning: {move:50, stack:0, prod:10, atk:35, def:5}.
+move:50 buys 1.6x recharge + 1.6x cap (so a fully-charged tile
+holds 19 work units, enough for a 3-strength shot at distance 5
+or a 5-strength shot at distance 3). atk:35 amplifies the
+Lanchester compounding on every fight. def is dumped because
+under Lanchester a bot with high atk wins ratio fights cleanly
+and rarely needs to absorb a hit. prod stays modest because
+Sniper's edge is about *where* you fight, not how much strength
+you produce — overcommitting to prod would starve the move
+budget that makes the strategy possible.
+
+Expected to dismantle bots that stay locked in adjacent-only
+play (the entire current lineage). Expected to lose to its
+mirror or to other ranged bots that can counter-snipe.`,
+  tech: { move: 50, stack: 0, prod: 10, atk: 35, def: 5 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) return;
+    const myPid = army.player.id;
+    const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
+    const w = game.map.width;
+    const h = game.map.height;
+    const budget = tile.budget;
+    const workCap = budget * BUDGET_FRACTION;
+    if (workCap <= 0.5) {
+      // Budget too low for a meaningful snipe — defer to local play.
+      Conqueror.act(army, game);
+      return;
+    }
+
+    let bestTarget = null;
+    let bestScore = -Infinity;
+    let bestPower = 0;
+    let bestDist = 0;
+
+    for (let dy = -RADIUS; dy <= RADIUS; dy++) {
+      for (let dx = -RADIUS; dx <= RADIUS; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const distSq = dx * dx + dy * dy;
+        if (distSq > RADIUS * RADIUS) continue;
+        const dist = Math.sqrt(distSq);
+        const tx = ((tile.pos.x + dx) % w + w) % w;
+        const ty = ((tile.pos.y + dy) % h + h) % h;
+        const target = game.map.getTile(tx, ty);
+        if (!target) continue;
+        const tArmies = target.armies;
+        if (tArmies.length === 0) continue; // empty — let Conqueror handle expansion
+        let friendly = false;
+        let enemy = 0;
+        for (let k = 0; k < tArmies.length; k++) {
+          const a = tArmies[k];
+          if (a.player.id === myPid) { friendly = true; break; }
+          enemy += a.strength;
+        }
+        if (friendly) continue;
+
+        // Max raw power we can deliver at this distance with the
+        // budget-fraction work cap. Also clamped by the army's own
+        // sLimit (we can't send more strength than we have).
+        const maxPowerByBudget = workCap / dist;
+        const maxPower = maxPowerByBudget < sLimit ? maxPowerByBudget : sLimit;
+        if (maxPower <= 0.5) continue;
+        // Under Lanchester we need post-fight effective > 0 with
+        // some margin. If maxPower * atkMult <= enemy, the fight is
+        // a loss. Need a comfortable margin so we don't trade for
+        // nothing.
+        if (maxPower * atkMult <= enemy * 1.15) continue;
+
+        const score = enemy - 0.3 * dist;
+        if (score > bestScore) {
+          bestScore = score;
+          bestTarget = target;
+          bestPower = maxPower;
+          bestDist = dist;
+        }
+      }
+    }
+
+    if (bestTarget) {
+      army.attack(bestTarget, bestPower);
+      return;
+    }
+
+    // No good snipe — adjacent action via parent chassis.
+    Conqueror.act(army, game);
+  },
+};

--- a/src/strategies/Sniper.js
+++ b/src/strategies/Sniper.js
@@ -1,142 +1,155 @@
-import Conqueror from "./Conqueror.js";
+import Parent from "./Conqueror_g13_b41df9.js";
 
 const BONUS = 1.4;
-// Don't burn the entire budget in one shot — leave headroom so we
-// can act again next tick if a better target appears. 0.7 means each
-// snipe spends at most 70% of available budget.
-const BUDGET_FRACTION = 0.7;
-// Search radius for vulnerable enemy tiles. Originally 5; v1's 60-bot
-// pool eval found that at radius 5 the maximum deliverable power
-// (cap * fraction / dist) is too small to kill anything past the
-// opening few ticks. Radius 3 keeps strikes meaningful — at the
-// budget-cap ceiling we can deliver ~6 strength at distance 3 vs ~3.6
-// at distance 5 — and most useful targets are within a few tiles
-// anyway on lab1's 30x22 map.
+// Search radius for vulnerable enemy tiles. 3 keeps strikes
+// meaningful given the budget cap; targets further than 3 tiles
+// rarely have enough work-units delivered to win Lanchester
+// cleanly under the cost-formula power*dist+1.
 const RADIUS = 3;
+// Keep at most this fraction of home strength out the door per
+// snipe. Source tile stays defendable.
+const MAX_SELF_COMMIT = 0.5;
+// Don't waste a snipe on tiny enemies — adjacent fallback can
+// pick those up cheaper without exposing the home.
+const MIN_TARGET_STRENGTH = 2.5;
+// Don't snipe at distance 1 — adjacent kill is the chassis's job
+// and goes through hemisphere/territory scoring; range only adds
+// value at distance 2+.
+const MIN_DISTANCE = 1.5;
+
+function hasAdjacentKill(neighbors, pid, sLimit) {
+  for (let d = 0; d < 4; d++) {
+    const t = neighbors[d];
+    if (!t) continue;
+    const tArmies = t.armies;
+    let friendly = false;
+    let enemy = 0;
+    for (let k = 0; k < tArmies.length; k++) {
+      const a = tArmies[k];
+      if (a.player.id === pid) { friendly = true; break; }
+      enemy += a.strength;
+    }
+    if (friendly) continue;
+    if (enemy > 0 && enemy / BONUS + 0.45 <= sLimit) return true;
+  }
+  return false;
+}
 
 export default {
   name: "Sniper",
   author: "claude",
   version: 1,
   description:
-    "Long-range teleport bot: each tick scans a 5-tile radius for a vulnerable enemy tile, then teleports decisive force from this army's home tile to land a decisive Lanchester kill.",
-  summary: `New ruleset (movementModel="budget", combatModel="lanchester")
-unlocks a strategy no Conqueror cousin can replicate: ranged
-teleport at non-adjacent targets. Sniper exploits this directly.
+    "Conqueror_g13 chassis + opportunistic ranged strike. Snipes only when (a) no adjacent kill available, (b) home tile has surplus strength, and (c) a vulnerable enemy is reachable for a clean Lanchester win — otherwise plays the validated chassis verbatim.",
+  summary: `Earlier Sniper drafts replaced Conqueror's chassis tech
+with high-move/low-prod loadouts to enable long shots. The chassis
+fallback then ran with terrible tech and the bot underperformed
+the lineage on the 90% of ticks where no snipe fired. Lesson: a
+rule-aware bot should be a strict upgrade — keep the chassis tech
+and gate the new behavior so it only fires when clearly beneficial.
 
-Per-army logic:
-  1. Scan tiles within RADIUS=5 (Euclidean) for an enemy tile that
-     this army can kill cleanly. The cost in work units (power x
-     distance) is capped at BUDGET_FRACTION * tile.budget so we
-     keep some recharge headroom for next tick.
-  2. Among kill candidates, pick the one that maximizes
-     (enemy_strength - 0.3 * distance) — score weights big targets
-     higher and slightly penalizes far shots (more costly for the
-     same delivered power).
-  3. If the candidate's required commit (under Lanchester: enough
-     to win cleanly given atk * BONUS attacker multiplier) fits in
-     the budget-fraction work cap, teleport and return.
-  4. Otherwise, fall through to Conqueror.act for local adjacent
-     action — the chassis handles routine kills/expansion well.
+Sniper now uses g14_8d5369's validated tech {move:76, stack:0,
+prod:16, atk:5, def:3}. The chassis logic is g13_b41df9 (the
+lineage's strategy parent). Sniper's only addition: before
+deferring to the chassis, check whether a clean ranged shot
+would beat the chassis's local action on the same tick.
 
-Tech is offense-leaning: {move:50, stack:0, prod:10, atk:35, def:5}.
-move:50 buys 1.6x recharge + 1.6x cap (so a fully-charged tile
-holds 19 work units, enough for a 3-strength shot at distance 5
-or a 5-strength shot at distance 3). atk:35 amplifies the
-Lanchester compounding on every fight. def is dumped because
-under Lanchester a bot with high atk wins ratio fights cleanly
-and rarely needs to absorb a hit. prod stays modest because
-Sniper's edge is about *where* you fight, not how much strength
-you produce — overcommitting to prod would starve the move
-budget that makes the strategy possible.
+Per army:
+  1. If an adjacent beatable kill is on the table, defer to chassis
+     immediately. The chassis's hemisphere/territory/retake-aware
+     pick is more valuable than any snipe.
+  2. No adjacent kill. Scan tiles at distance > 1, <= 3, for an
+     enemy where:
+       - enemy strength >= 2.5 (worth the +1 move overhead)
+       - we can deliver minimum-Lanchester power with 1.0 raw
+         strength surviving on the captured tile
+       - that minPower <= 50% of our attackPower (keep home base)
+       - the work cost (minPower*dist+1) fits in tile.budget * 0.7
+  3. If a target qualifies, snipe with minPower exactly. Otherwise,
+     defer to chassis.
 
-Expected to dismantle bots that stay locked in adjacent-only
-play (the entire current lineage). Expected to lose to its
-mirror or to other ranged bots that can counter-snipe.`,
-  tech: { move: 50, stack: 0, prod: 25, atk: 20, def: 5 },
+Snipe only happens on idle frontier ticks where chassis has no
+kill — those are the ticks where chassis would otherwise reinforce
+a maxed friendly or take a low-value empty tile, both wasteful
+under cost = power*dist+1. Sniping at range converts a wasted
+overhead into a real kill.
+
+Tech mirrors the chassis champion so the snipe path adds value
+without taking any away.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;
     const sLimit = army.attackPower;
     if (sLimit <= 0.5) return;
-    const myPid = army.player.id;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+
+    // Defer to chassis when an adjacent kill is on the table.
+    if (hasAdjacentKill(neighbors, pid, sLimit)) {
+      Parent.act(army, game);
+      return;
+    }
+
+    // No adjacent kill — try a snipe.
     const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
     const w = game.map.width;
     const h = game.map.height;
     const budget = tile.budget;
-    const workCap = budget * BUDGET_FRACTION;
+    const workCap = budget * 0.7;
+    if (workCap > 1) {
+      let bestTarget = null;
+      let bestScore = -Infinity;
+      let bestPower = 0;
+      const maxSelfCommit = sLimit * MAX_SELF_COMMIT;
 
-    // Hard rule: never commit more than half this army's strength to
-    // a snipe. v1/v2 of Sniper sent full attackPower to remote
-    // targets, leaving the source tile at ~0.5 strength — instant
-    // kill by any adjacent enemy next tick. Keeping >=50% home
-    // preserves the launch base.
-    const maxSelfCommit = sLimit * 0.5;
+      for (let dy = -RADIUS; dy <= RADIUS; dy++) {
+        for (let dx = -RADIUS; dx <= RADIUS; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const distSq = dx * dx + dy * dy;
+          if (distSq > RADIUS * RADIUS) continue;
+          const dist = Math.sqrt(distSq);
+          if (dist < MIN_DISTANCE) continue;
+          const tx = ((tile.pos.x + dx) % w + w) % w;
+          const ty = ((tile.pos.y + dy) % h + h) % h;
+          const target = game.map.getTile(tx, ty);
+          if (!target) continue;
+          const tArmies = target.armies;
+          if (tArmies.length === 0) continue;
+          let friendly = false;
+          let enemy = 0;
+          for (let k = 0; k < tArmies.length; k++) {
+            const a = tArmies[k];
+            if (a.player.id === pid) { friendly = true; break; }
+            enemy += a.strength;
+          }
+          if (friendly) continue;
+          if (enemy < MIN_TARGET_STRENGTH) continue;
 
-    if (workCap <= 0.5) {
-      Conqueror.act(army, game);
-      return;
-    }
+          // Min Lanchester power that leaves >= 1.0 raw strength
+          // on the captured tile. Add 1.1x safety margin.
+          const minPower = Math.sqrt(1.0 + (enemy / atkMult) ** 2) * 1.1;
+          // Cost formula: power * dist + 1. Max deliverable power
+          // at this distance, given the work cap.
+          const maxPowerByBudget = (workCap - 1) / dist;
+          const ceiling = Math.min(maxPowerByBudget, maxSelfCommit, sLimit);
+          if (minPower > ceiling) continue;
 
-    let bestTarget = null;
-    let bestScore = -Infinity;
-    let bestPower = 0;
-
-    for (let dy = -RADIUS; dy <= RADIUS; dy++) {
-      for (let dx = -RADIUS; dx <= RADIUS; dx++) {
-        if (dx === 0 && dy === 0) continue;
-        const distSq = dx * dx + dy * dy;
-        if (distSq > RADIUS * RADIUS) continue;
-        const dist = Math.sqrt(distSq);
-        const tx = ((tile.pos.x + dx) % w + w) % w;
-        const ty = ((tile.pos.y + dy) % h + h) % h;
-        const target = game.map.getTile(tx, ty);
-        if (!target) continue;
-        const tArmies = target.armies;
-        if (tArmies.length === 0) continue;
-        let friendly = false;
-        let enemy = 0;
-        for (let k = 0; k < tArmies.length; k++) {
-          const a = tArmies[k];
-          if (a.player.id === myPid) { friendly = true; break; }
-          enemy += a.strength;
+          const score = enemy - 0.3 * dist;
+          if (score > bestScore) {
+            bestScore = score;
+            bestTarget = target;
+            bestPower = minPower;
+          }
         }
-        if (friendly) continue;
-        // Don't waste a snipe on trivial enemies — adjacent fallback
-        // can pick those up cheaper and without exposing the home.
-        if (enemy < 2.0) continue;
+      }
 
-        // Minimum-but-margin commit under Lanchester: pick the
-        // smallest P such that sqrt((P*atkMult)^2 - enemy^2) leaves
-        // us at least 1.0 raw strength on the captured tile after.
-        // Closed form: P >= sqrt(1.0^2 + (enemy/atkMult)^2). Add a
-        // 1.1x safety margin to absorb tile-defense or simultaneous
-        // arrivals.
-        const minPower = Math.sqrt(1.0 + (enemy / atkMult) ** 2) * 1.1;
-        // Cap by all three constraints: budget at this distance, the
-        // army's keep-half-home rule, and the army's strength. Cost
-        // formula is power * distance + 1, so max deliverable power
-        // at this distance is (workCap - 1) / dist.
-        const maxPowerByBudget = (workCap - 1) / dist;
-        const ceiling = Math.min(maxPowerByBudget, maxSelfCommit, sLimit);
-        if (minPower > ceiling) continue;
-
-        // Score: prefer killing the biggest reachable enemy and
-        // slightly prefer closer (cheaper, more reliable).
-        const score = enemy - 0.3 * dist;
-        if (score > bestScore) {
-          bestScore = score;
-          bestTarget = target;
-          bestPower = minPower;
-        }
+      if (bestTarget) {
+        army.attack(bestTarget, bestPower);
+        return;
       }
     }
 
-    if (bestTarget) {
-      army.attack(bestTarget, bestPower);
-      return;
-    }
-
-    Conqueror.act(army, game);
+    Parent.act(army, game);
   },
 };

--- a/src/strategies/Sniper.js
+++ b/src/strategies/Sniper.js
@@ -53,7 +53,7 @@ budget that makes the strategy possible.
 Expected to dismantle bots that stay locked in adjacent-only
 play (the entire current lineage). Expected to lose to its
 mirror or to other ranged bots that can counter-snipe.`,
-  tech: { move: 75, stack: 0, prod: 5, atk: 15, def: 5 },
+  tech: { move: 50, stack: 0, prod: 25, atk: 20, def: 5 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;
@@ -65,8 +65,15 @@ mirror or to other ranged bots that can counter-snipe.`,
     const h = game.map.height;
     const budget = tile.budget;
     const workCap = budget * BUDGET_FRACTION;
+
+    // Hard rule: never commit more than half this army's strength to
+    // a snipe. v1/v2 of Sniper sent full attackPower to remote
+    // targets, leaving the source tile at ~0.5 strength — instant
+    // kill by any adjacent enemy next tick. Keeping >=50% home
+    // preserves the launch base.
+    const maxSelfCommit = sLimit * 0.5;
+
     if (workCap <= 0.5) {
-      // Budget too low for a meaningful snipe — defer to local play.
       Conqueror.act(army, game);
       return;
     }
@@ -74,7 +81,6 @@ mirror or to other ranged bots that can counter-snipe.`,
     let bestTarget = null;
     let bestScore = -Infinity;
     let bestPower = 0;
-    let bestDist = 0;
 
     for (let dy = -RADIUS; dy <= RADIUS; dy++) {
       for (let dx = -RADIUS; dx <= RADIUS; dx++) {
@@ -87,7 +93,7 @@ mirror or to other ranged bots that can counter-snipe.`,
         const target = game.map.getTile(tx, ty);
         if (!target) continue;
         const tArmies = target.armies;
-        if (tArmies.length === 0) continue; // empty — let Conqueror handle expansion
+        if (tArmies.length === 0) continue;
         let friendly = false;
         let enemy = 0;
         for (let k = 0; k < tArmies.length; k++) {
@@ -96,25 +102,30 @@ mirror or to other ranged bots that can counter-snipe.`,
           enemy += a.strength;
         }
         if (friendly) continue;
+        // Don't waste a snipe on trivial enemies — adjacent fallback
+        // can pick those up cheaper and without exposing the home.
+        if (enemy < 2.0) continue;
 
-        // Max raw power we can deliver at this distance with the
-        // budget-fraction work cap. Also clamped by the army's own
-        // sLimit (we can't send more strength than we have).
+        // Minimum-but-margin commit under Lanchester: pick the
+        // smallest P such that sqrt((P*atkMult)^2 - enemy^2) leaves
+        // us at least 1.0 raw strength on the captured tile after.
+        // Closed form: P >= sqrt(1.0^2 + (enemy/atkMult)^2). Add a
+        // 1.1x safety margin to absorb tile-defense or simultaneous
+        // arrivals.
+        const minPower = Math.sqrt(1.0 + (enemy / atkMult) ** 2) * 1.1;
+        // Cap by all three constraints: budget at this distance, the
+        // army's keep-half-home rule, and the army's strength.
         const maxPowerByBudget = workCap / dist;
-        const maxPower = maxPowerByBudget < sLimit ? maxPowerByBudget : sLimit;
-        if (maxPower <= 0.5) continue;
-        // Under Lanchester we need post-fight effective > 0 with
-        // some margin. If maxPower * atkMult <= enemy, the fight is
-        // a loss. Need a comfortable margin so we don't trade for
-        // nothing.
-        if (maxPower * atkMult <= enemy * 1.15) continue;
+        const ceiling = Math.min(maxPowerByBudget, maxSelfCommit, sLimit);
+        if (minPower > ceiling) continue;
 
+        // Score: prefer killing the biggest reachable enemy and
+        // slightly prefer closer (cheaper, more reliable).
         const score = enemy - 0.3 * dist;
         if (score > bestScore) {
           bestScore = score;
           bestTarget = target;
-          bestPower = maxPower;
-          bestDist = dist;
+          bestPower = minPower;
         }
       }
     }
@@ -124,7 +135,6 @@ mirror or to other ranged bots that can counter-snipe.`,
       return;
     }
 
-    // No good snipe — adjacent action via parent chassis.
     Conqueror.act(army, game);
   },
 };

--- a/src/strategies/Sniper.js
+++ b/src/strategies/Sniper.js
@@ -5,10 +5,14 @@ const BONUS = 1.4;
 // can act again next tick if a better target appears. 0.7 means each
 // snipe spends at most 70% of available budget.
 const BUDGET_FRACTION = 0.7;
-// Search radius for vulnerable enemy tiles. 5 covers most of lab1's
-// 30x22 board within a reasonable scan, and the budget cap (12 *
-// moveRecharge) limits useful range anyway.
-const RADIUS = 5;
+// Search radius for vulnerable enemy tiles. Originally 5; v1's 60-bot
+// pool eval found that at radius 5 the maximum deliverable power
+// (cap * fraction / dist) is too small to kill anything past the
+// opening few ticks. Radius 3 keeps strikes meaningful — at the
+// budget-cap ceiling we can deliver ~6 strength at distance 3 vs ~3.6
+// at distance 5 — and most useful targets are within a few tiles
+// anyway on lab1's 30x22 map.
+const RADIUS = 3;
 
 export default {
   name: "Sniper",
@@ -49,7 +53,7 @@ budget that makes the strategy possible.
 Expected to dismantle bots that stay locked in adjacent-only
 play (the entire current lineage). Expected to lose to its
 mirror or to other ranged bots that can counter-snipe.`,
-  tech: { move: 50, stack: 0, prod: 10, atk: 35, def: 5 },
+  tech: { move: 75, stack: 0, prod: 5, atk: 15, def: 5 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;

--- a/src/strategies/Stockpile.js
+++ b/src/strategies/Stockpile.js
@@ -1,16 +1,18 @@
-import Conqueror from "./Conqueror.js";
+import Parent from "./Conqueror_g13_b41df9.js";
 
 const BONUS = 1.4;
-// Frontier tiles always act — no point hoarding budget when there's
-// an enemy adjacent. Interior tiles (no enemy adjacent and all
-// friendly neighbors near-cap) idle to let budget recharge to its
-// move-tech-scaled cap, then occasionally launch a long-range
-// teleport at a high-value vulnerable enemy.
-const SCAN_RADIUS = 4;
-// Idle threshold: don't act on interior tiles unless budget is at
-// least this fraction of the cap. Lower = more acts (less saving),
-// higher = bigger but rarer strikes.
-const STRIKE_BUDGET_FRACTION = 0.85;
+// Search radius for opportunistic ranged strikes from interior
+// tiles. Same constraint as Sniper — at distance > 3 the cost
+// formula power*dist+1 plus a meaningful power requires more
+// budget than even a fully-charged tile typically holds.
+const SCAN_RADIUS = 3;
+// Trigger interior strike when tile budget exceeds this fraction of
+// the budget cap. 0.85 means we wait until the tile is nearly
+// charged before firing.
+const STRIKE_THRESHOLD = 0.85;
+// Min target enemy strength worth a ranged strike — small enemies
+// are best handled by adjacent kills (someone else's job).
+const MIN_TARGET_STRENGTH = 2.5;
 
 function isInterior(tile, pid) {
   const n = tile.neighbors;
@@ -18,17 +20,16 @@ function isInterior(tile, pid) {
     const t = n[i];
     if (!t) continue;
     const armies = t.armies;
-    if (armies.length === 0) return false; // empty neighbor = expand opportunity
+    if (armies.length === 0) return false;
     let foundFriendly = false;
     for (let k = 0; k < armies.length; k++) {
       const a = armies[k];
       if (a.player.id === pid) {
         foundFriendly = true;
-        // Friendly with room = reinforce opportunity.
         if (a.strength < a.maxStrength - 0.5) return false;
       }
     }
-    if (!foundFriendly) return false; // enemy adjacent — frontier
+    if (!foundFriendly) return false;
   }
   return true;
 }
@@ -38,78 +39,62 @@ export default {
   author: "claude",
   version: 1,
   description:
-    "Frontier tiles play Conqueror; interior tiles idle to let the per-tile budget cap charge fully, then teleport opportunistic alphas at vulnerable enemies across the map.",
-  summary: `New ruleset (movementModel="budget") gives high-move tiles
-a meaningful storage capacity (move:60 -> ~2.0x base cap = 24 work
-units on lab1). Most bots burn this every tick without realizing
-the cap exists; Stockpile turns it into a strategic resource.
+    "Conqueror_g13 chassis on the frontier; interior tiles idle to let budget charge to cap, then teleport opportunistic alphas at vulnerable enemies in range. Strict upgrade over the chassis: idle saves the +1 move overhead, ranged strikes monetize otherwise-wasted budget.",
+  summary: `An earlier Stockpile draft replaced the chassis tech with
+high-move/low-prod to enable big alphas. The chassis fallback then
+ran with starved tech and the bot underperformed on most ticks. v2
+keeps g14_8d5369's validated chassis tech and adds two thin
+behaviors that should each be a strict upgrade:
 
-Per-army logic:
-  1. Frontier check: if any neighbor is empty, owned by an enemy,
-     or contains a non-cap friendly that wants reinforcement, this
-     tile is on a frontier — defer entirely to Conqueror.act for
-     normal adjacent play. Frontier budget is best spent now.
-  2. Otherwise the tile is interior. If tile.budget < 0.85 * cap
-     (cap is just budget * 1.0 here, see note below), idle this
-     tick — let budget recharge.
-  3. Tile is interior AND budget is near cap. Scan SCAN_RADIUS=4
-     for the best enemy-tile target where work-cost (power x
-     distance) fits in available budget AND the resulting commit
-     wins under Lanchester (effective W > 1.15x effective L).
-  4. Land the teleport. The captured tile resets to budget=0 by
-     conquest rule, but our home tile keeps any leftover budget
-     so we can refill faster.
+  1. Frontier (any non-friendly neighbor or non-cap friendly):
+     defer to the chassis (Conqueror_g13_b41df9). The chassis is
+     already validated against the lineage in this case.
+  2. Interior (all neighbors are maxed friendlies): the chassis
+     would Pass-3 stencil into a wasted reinforce or do nothing
+     useful. Instead, gate on tile.budget >= 0.85 * cap. If the
+     budget is near full, scan for a vulnerable enemy in range
+     <=3 and fire a min-Lanchester teleport. Otherwise, idle.
 
-Step 2's cap reference: we don't have direct access to the
-maxBudget * moveRecharge cap from the strategy, so we infer the
-cap as "budget at the highest value we've observed" via a
-per-army state field. Simpler proxy: budget is "near cap" once it
-stops growing. We use a reasonable fixed threshold (BUDGET >= 8)
-that approximates 85% of the typical capped budget under move:60
-on lab1 — close enough; the goal is "wait for nearly full,"
-not "wait for exactly full."
+Idle tiles avoid paying the +1 move-overhead. Range strikes only
+fire when the chassis would have done a low-value action anyway,
+so the bot is at minimum chassis-equivalent and sometimes better.
 
-Tech: {move:60, stack:0, prod:5, atk:25, def:10}. move:60 buys
-2.0x recharge + 2.0x cap (24 work units) — the storage matters
-for Stockpile and 2x recharge keeps the strategy responsive.
-prod:5 is intentionally weak: Stockpile's interior tiles are
-already saturated at maxArmy, so prod past that is wasted on
-them; the bot's edge is in *spending* saved-up budget, not in
-producing more strength. atk:25 amplifies Lanchester for
-strikes. def:10 light cushion.
+The cap-aware threshold is approximate: we don't have direct
+access to the maxBudget * moveRecharge cap from the strategy.
+Move:76 -> moveRecharge ~2.12 -> cap ~25.4. 0.85 * 25.4 = ~21.6;
+we use a slightly softer floor of 16 budget to also work for
+lower-move techs.
 
-Expected wins: against bots that fritter budget every tick on
-maxed-friendly reinforcement (every existing Conqueror). Expected
-losses: in long matches where the interior never gets a clean
-snipe and Stockpile is just a passive Conqueror — and in mirror
-matches where neither bot finds a target.`,
-  tech: { move: 60, stack: 0, prod: 5, atk: 25, def: 10 },
+Tech mirrors the chassis champion {move:76, stack:0, prod:16,
+atk:5, def:3} so the rule-aware additions are pure strict upgrade.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
   act(army, game) {
     const tile = army.tile;
     if (!tile) return;
     const sLimit = army.attackPower;
-    if (sLimit <= 0.5) return;
+    if (sLimit <= 0.5) {
+      Parent.act(army, game);
+      return;
+    }
     const pid = army.player.id;
 
-    // Frontier? Defer to Conqueror immediately.
+    // Frontier? Defer to chassis.
     if (!isInterior(tile, pid)) {
-      Conqueror.act(army, game);
+      Parent.act(army, game);
       return;
     }
 
-    // Interior. Wait until budget is near cap before we strike.
-    // Approximate threshold: under move:60 (this bot's tech), cap
-    // is maxBudget * 2.0 = 24 on lab1; 85% of that is ~20.
-    // We use a softer floor that also works for lower-move
-    // techs in case this strategy is ever loaded with a different
-    // loadout: budget must be at least 8 (~67% of neutral cap).
-    if (tile.budget < 8) return;
+    // Interior with low budget: idle (don't pay +1 overhead for
+    // wasted reinforce moves).
+    if (tile.budget < 16) return;
 
-    // Scan for a vulnerable enemy in range.
+    // Budget is near cap. Scan for a ranged strike.
     const w = game.map.width;
     const h = game.map.height;
     const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
     const budget = tile.budget;
+    const workCap = budget * 0.7;
+
     let bestTarget = null;
     let bestScore = -Infinity;
     let bestPower = 0;
@@ -134,17 +119,19 @@ matches where neither bot finds a target.`,
           enemy += a.strength;
         }
         if (friendly) continue;
-        // Cost formula: power * dist + 1. Max deliverable power is
-        // (budget - 1) / dist.
-        const maxPowerByBudget = (budget - 1) / dist;
-        const maxPower = maxPowerByBudget < sLimit ? maxPowerByBudget : sLimit;
-        if (maxPower <= 0.5) continue;
-        if (maxPower * atkMult <= enemy * 1.15) continue;
+        if (enemy < MIN_TARGET_STRENGTH) continue;
+
+        const minPower = Math.sqrt(1.0 + (enemy / atkMult) ** 2) * 1.1;
+        const maxPowerByBudget = (workCap - 1) / dist;
+        const maxSelfCommit = sLimit * 0.5;
+        const ceiling = Math.min(maxPowerByBudget, maxSelfCommit, sLimit);
+        if (minPower > ceiling) continue;
+
         const score = enemy - 0.2 * dist;
         if (score > bestScore) {
           bestScore = score;
           bestTarget = target;
-          bestPower = maxPower;
+          bestPower = minPower;
         }
       }
     }
@@ -154,6 +141,8 @@ matches where neither bot finds a target.`,
       return;
     }
 
-    // Nothing to strike. Stay idle this tick — preserve budget.
+    // No clean strike, full budget — let chassis fall through (it
+    // may find a stencil move worth the overhead).
+    Parent.act(army, game);
   },
 };

--- a/src/strategies/Stockpile.js
+++ b/src/strategies/Stockpile.js
@@ -134,7 +134,9 @@ matches where neither bot finds a target.`,
           enemy += a.strength;
         }
         if (friendly) continue;
-        const maxPowerByBudget = budget / dist;
+        // Cost formula: power * dist + 1. Max deliverable power is
+        // (budget - 1) / dist.
+        const maxPowerByBudget = (budget - 1) / dist;
         const maxPower = maxPowerByBudget < sLimit ? maxPowerByBudget : sLimit;
         if (maxPower <= 0.5) continue;
         if (maxPower * atkMult <= enemy * 1.15) continue;

--- a/src/strategies/Stockpile.js
+++ b/src/strategies/Stockpile.js
@@ -1,0 +1,157 @@
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+// Frontier tiles always act — no point hoarding budget when there's
+// an enemy adjacent. Interior tiles (no enemy adjacent and all
+// friendly neighbors near-cap) idle to let budget recharge to its
+// move-tech-scaled cap, then occasionally launch a long-range
+// teleport at a high-value vulnerable enemy.
+const SCAN_RADIUS = 4;
+// Idle threshold: don't act on interior tiles unless budget is at
+// least this fraction of the cap. Lower = more acts (less saving),
+// higher = bigger but rarer strikes.
+const STRIKE_BUDGET_FRACTION = 0.85;
+
+function isInterior(tile, pid) {
+  const n = tile.neighbors;
+  for (let i = 0; i < 4; i++) {
+    const t = n[i];
+    if (!t) continue;
+    const armies = t.armies;
+    if (armies.length === 0) return false; // empty neighbor = expand opportunity
+    let foundFriendly = false;
+    for (let k = 0; k < armies.length; k++) {
+      const a = armies[k];
+      if (a.player.id === pid) {
+        foundFriendly = true;
+        // Friendly with room = reinforce opportunity.
+        if (a.strength < a.maxStrength - 0.5) return false;
+      }
+    }
+    if (!foundFriendly) return false; // enemy adjacent — frontier
+  }
+  return true;
+}
+
+export default {
+  name: "Stockpile",
+  author: "claude",
+  version: 1,
+  description:
+    "Frontier tiles play Conqueror; interior tiles idle to let the per-tile budget cap charge fully, then teleport opportunistic alphas at vulnerable enemies across the map.",
+  summary: `New ruleset (movementModel="budget") gives high-move tiles
+a meaningful storage capacity (move:60 -> ~2.0x base cap = 24 work
+units on lab1). Most bots burn this every tick without realizing
+the cap exists; Stockpile turns it into a strategic resource.
+
+Per-army logic:
+  1. Frontier check: if any neighbor is empty, owned by an enemy,
+     or contains a non-cap friendly that wants reinforcement, this
+     tile is on a frontier — defer entirely to Conqueror.act for
+     normal adjacent play. Frontier budget is best spent now.
+  2. Otherwise the tile is interior. If tile.budget < 0.85 * cap
+     (cap is just budget * 1.0 here, see note below), idle this
+     tick — let budget recharge.
+  3. Tile is interior AND budget is near cap. Scan SCAN_RADIUS=4
+     for the best enemy-tile target where work-cost (power x
+     distance) fits in available budget AND the resulting commit
+     wins under Lanchester (effective W > 1.15x effective L).
+  4. Land the teleport. The captured tile resets to budget=0 by
+     conquest rule, but our home tile keeps any leftover budget
+     so we can refill faster.
+
+Step 2's cap reference: we don't have direct access to the
+maxBudget * moveRecharge cap from the strategy, so we infer the
+cap as "budget at the highest value we've observed" via a
+per-army state field. Simpler proxy: budget is "near cap" once it
+stops growing. We use a reasonable fixed threshold (BUDGET >= 8)
+that approximates 85% of the typical capped budget under move:60
+on lab1 — close enough; the goal is "wait for nearly full,"
+not "wait for exactly full."
+
+Tech: {move:60, stack:0, prod:5, atk:25, def:10}. move:60 buys
+2.0x recharge + 2.0x cap (24 work units) — the storage matters
+for Stockpile and 2x recharge keeps the strategy responsive.
+prod:5 is intentionally weak: Stockpile's interior tiles are
+already saturated at maxArmy, so prod past that is wasted on
+them; the bot's edge is in *spending* saved-up budget, not in
+producing more strength. atk:25 amplifies Lanchester for
+strikes. def:10 light cushion.
+
+Expected wins: against bots that fritter budget every tick on
+maxed-friendly reinforcement (every existing Conqueror). Expected
+losses: in long matches where the interior never gets a clean
+snipe and Stockpile is just a passive Conqueror — and in mirror
+matches where neither bot finds a target.`,
+  tech: { move: 60, stack: 0, prod: 5, atk: 25, def: 10 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) return;
+    const pid = army.player.id;
+
+    // Frontier? Defer to Conqueror immediately.
+    if (!isInterior(tile, pid)) {
+      Conqueror.act(army, game);
+      return;
+    }
+
+    // Interior. Wait until budget is near cap before we strike.
+    // Approximate threshold: under move:60 (this bot's tech), cap
+    // is maxBudget * 2.0 = 24 on lab1; 85% of that is ~20.
+    // We use a softer floor that also works for lower-move
+    // techs in case this strategy is ever loaded with a different
+    // loadout: budget must be at least 8 (~67% of neutral cap).
+    if (tile.budget < 8) return;
+
+    // Scan for a vulnerable enemy in range.
+    const w = game.map.width;
+    const h = game.map.height;
+    const atkMult = (army.player.techMults?.atk ?? 1) * BONUS;
+    const budget = tile.budget;
+    let bestTarget = null;
+    let bestScore = -Infinity;
+    let bestPower = 0;
+
+    for (let dy = -SCAN_RADIUS; dy <= SCAN_RADIUS; dy++) {
+      for (let dx = -SCAN_RADIUS; dx <= SCAN_RADIUS; dx++) {
+        if (dx === 0 && dy === 0) continue;
+        const distSq = dx * dx + dy * dy;
+        if (distSq > SCAN_RADIUS * SCAN_RADIUS) continue;
+        const dist = Math.sqrt(distSq);
+        const tx = ((tile.pos.x + dx) % w + w) % w;
+        const ty = ((tile.pos.y + dy) % h + h) % h;
+        const target = game.map.getTile(tx, ty);
+        if (!target) continue;
+        const tArmies = target.armies;
+        if (tArmies.length === 0) continue;
+        let friendly = false;
+        let enemy = 0;
+        for (let k = 0; k < tArmies.length; k++) {
+          const a = tArmies[k];
+          if (a.player.id === pid) { friendly = true; break; }
+          enemy += a.strength;
+        }
+        if (friendly) continue;
+        const maxPowerByBudget = budget / dist;
+        const maxPower = maxPowerByBudget < sLimit ? maxPowerByBudget : sLimit;
+        if (maxPower <= 0.5) continue;
+        if (maxPower * atkMult <= enemy * 1.15) continue;
+        const score = enemy - 0.2 * dist;
+        if (score > bestScore) {
+          bestScore = score;
+          bestTarget = target;
+          bestPower = maxPower;
+        }
+      }
+    }
+
+    if (bestTarget) {
+      army.attack(bestTarget, bestPower);
+      return;
+    }
+
+    // Nothing to strike. Stay idle this tick — preserve budget.
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -39,6 +39,7 @@ import Skirmisher from "./Skirmisher.js";
 import Tempo from "./Tempo.js";
 import Empire from "./Empire.js";
 import Settler from "./Settler.js";
+import Drumline from "./Drumline.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -89,6 +90,7 @@ export const ALL_STRATEGY_LIST = [
   Tempo,
   Empire,
   Settler,
+  Drumline,
   ...GENERATED,
   ...DESCENDANTS,
 ];

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -40,6 +40,9 @@ import Tempo from "./Tempo.js";
 import Empire from "./Empire.js";
 import Settler from "./Settler.js";
 import Drumline from "./Drumline.js";
+import Sniper from "./Sniper.js";
+import Hammer from "./Hammer.js";
+import Stockpile from "./Stockpile.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -91,6 +94,9 @@ export const ALL_STRATEGY_LIST = [
   Empire,
   Settler,
   Drumline,
+  Sniper,
+  Hammer,
+  Stockpile,
   ...GENERATED,
   ...DESCENDANTS,
 ];

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -43,6 +43,7 @@ import Drumline from "./Drumline.js";
 import Sniper from "./Sniper.js";
 import Hammer from "./Hammer.js";
 import Stockpile from "./Stockpile.js";
+import Reservoir from "./Reservoir.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -97,6 +98,7 @@ export const ALL_STRATEGY_LIST = [
   Sniper,
   Hammer,
   Stockpile,
+  Reservoir,
   ...GENERATED,
   ...DESCENDANTS,
 ];

--- a/tournament/eras.js
+++ b/tournament/eras.js
@@ -142,20 +142,25 @@ async function main() {
   const { eras, champions } = pickEraChampions(rankings, lineages, opts.top, opts.minPlayed);
 
   // Pin a specific bot if requested. If it's already a champion, nothing
-  // changes; otherwise we add it with whatever lineage/rating data we
-  // have so it still gets reported in the per-era summary.
+  // changes; otherwise we add it with whatever metadata we can find. A
+  // brand-new bot (not in rankings.json yet) is allowed — it just needs
+  // to exist in ALL_STRATEGIES — so we can use eras.js as an evaluation
+  // harness for newly-written candidates against the historical pool.
   if (opts.pin && !champions.has(opts.pin)) {
     const p = rankings.players.find((x) => x.name === opts.pin);
-    if (!p) throw new Error(`--pin ${opts.pin}: not in rankings.json`);
     const ln = lineages.find((b) => b.name === opts.pin);
+    if (!p && !ALL_STRATEGIES[opts.pin]) {
+      throw new Error(`--pin ${opts.pin}: not in rankings.json or ALL_STRATEGIES`);
+    }
     champions.set(opts.pin, {
-      name: p.name,
-      rating: p.rating,
-      matches: p.matches,
-      wins: p.wins,
+      name: opts.pin,
+      rating: p?.rating ?? null,
+      matches: p?.matches ?? 0,
+      wins: p?.wins ?? 0,
       generation: ln?.generation ?? null,
     });
-    console.log(`Pinned ${opts.pin} into the field (gen ${ln?.generation ?? "?"}, rating ${p.rating}).`);
+    const ratingStr = p ? `rating ${p.rating}` : "no prior rating";
+    console.log(`Pinned ${opts.pin} into the field (gen ${ln?.generation ?? "?"}, ${ratingStr}).`);
   }
 
   console.log(`\nEra champions (top ${opts.top} per generation, min ${opts.minPlayed} matches):`);

--- a/tournament/eras.js
+++ b/tournament/eras.js
@@ -1,34 +1,43 @@
 #!/usr/bin/env node
-// Cross-era tournament: take the top-K bots from each of N intervals
-// across the full match log, then run them against each other in a
-// fresh rating tournament. The point is to see whether bots are
-// actually getting better over the loop's lifetime — something the
-// global PL ranking can't show, because its geometric-mean
-// normalization rebases the median to ~1000 every iteration.
+// Cross-era tournament keyed off bot generation.
+//
+// "Era" = generation. Naming convention `Conqueror_gN_xxxxxx` makes
+// generation a clean era proxy: it advances every time the spawn loop
+// produces a descendant, so g14 is older than g15 by construction.
+// Earlier versions of this tool sliced the match log by timestamp; the
+// generation-based view is preferred because it is independent of how
+// densely the loop ran during any given period and works without the
+// (gitignored) matches.jsonl.
 //
 // Pipeline:
-//   1. Load matches.jsonl, filter to current rules version, sort by ts.
-//   2. Divide into N equal-count intervals. At each interval's right
-//      edge, fit PL on the cumulative matches up to that point and
-//      identify the top-K bots of that era (with a min-played
-//      threshold so a bot with 2 lucky matches doesn't represent an
-//      era).
-//   3. Union the era champions into a single field; resolve each name
-//      via ALL_STRATEGIES so archived bots can still play.
-//   4. Run a rating tournament with the era field. The resulting
-//      standings tell you whether late-era bots out-rate early-era
-//      bots in head-to-head play.
+//   1. Load rankings.json + lineages.json. Bucket bots by generation.
+//   2. Per generation, pick the top-`top` bots that have at least
+//      `--min-played` matches under the current rules version.
+//   3. Optionally `--pin` a specific bot into the field (e.g. a fresh
+//      newcomer you want to evaluate against older champions).
+//   4. Resolve names via ALL_STRATEGIES (archived bots remain loadable).
+//   5. Run runRatingTournament. Fresh PL fit on just these matches —
+//      independent of the global ranking, so it tests whether a bot's
+//      global rating reflects head-to-head dominance or is a
+//      current-pool artifact.
+//   6. Report cross-era rating + winRate side-by-side, per-era avg
+//      rank/rating, and (if --pin) the pinned bot's pairwise win-rate
+//      vs every opponent it shared a match with. Spearman rho between
+//      cross-era rating and cross-era winRate quantifies how well the
+//      rating tracks raw wins.
 //
 // Usage:
 //   node tournament/eras.js
-//   node tournament/eras.js --intervals 10 --top 3 --matches 250
-//   node tournament/eras.js --map lab1 --pool 5
+//   node tournament/eras.js --pin Conqueror_g14_8d5369
+//   node tournament/eras.js --top 2 --matches 400 --map lab1
+//   node tournament/eras.js --no-append           # don't persist to log
 
 import { ALL_STRATEGIES } from "../src/strategies/index.js";
 import { MAPS } from "./maps.js";
 import { runRatingTournament } from "./scheduler.js";
 import { buildMatchEntry, appendMatches, loadMatches, getMatchLogPath } from "./matchLog.js";
-import { saveRankings, getRankingsPath } from "./rankingsStore.js";
+import { loadRankings, saveRankings, getRankingsPath } from "./rankingsStore.js";
+import { loadLineages } from "./lineageStore.js";
 import { buildRankings, filterCurrentVersion } from "./rank.js";
 import { writeFile } from "node:fs/promises";
 import { resolve, dirname } from "node:path";
@@ -39,26 +48,26 @@ const OUT_PATH = resolve(HERE, "eras.json");
 
 function parseArgs(argv) {
   const opts = {
-    intervals: 10,
-    top: 3,
-    matches: 250,
+    top: 1,
+    matches: 400,
     pool: null,
     map: "lab1",
     seed: 1,
-    minPlayedInEra: 15,
+    minPlayed: 15,
+    pin: null,
     append: true,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     const next = () => argv[++i];
     switch (a) {
-      case "--intervals": opts.intervals = parseInt(next(), 10); break;
       case "--top": opts.top = parseInt(next(), 10); break;
       case "--matches": opts.matches = parseInt(next(), 10); break;
       case "--pool": opts.pool = parseInt(next(), 10); break;
       case "--map": opts.map = next(); break;
       case "--seed": opts.seed = parseInt(next(), 10); break;
-      case "--min-played": opts.minPlayedInEra = parseInt(next(), 10); break;
+      case "--min-played": opts.minPlayed = parseInt(next(), 10); break;
+      case "--pin": opts.pin = next(); break;
       case "--no-append": opts.append = false; break;
       default: throw new Error(`Unknown option: ${a}`);
     }
@@ -66,44 +75,36 @@ function parseArgs(argv) {
   return opts;
 }
 
-function pickEraChampions(matches, intervals, top, minPlayed) {
-  // For each interval i in [1..intervals], compute PL on matches[0..end_i]
-  // and grab the top `top` bots that played at least `minPlayed` matches
-  // in that era's window. Returns per-era info plus deduplicated field.
-  const total = matches.length;
-  const eras = [];
-  const seen = new Map(); // name -> { firstEra, eras: [{i, rating, matches}] }
-
-  for (let i = 1; i <= intervals; i++) {
-    const endIdx = Math.floor((total * i) / intervals);
-    const slice = matches.slice(0, endIdx);
-    const ranking = buildRankings(slice);
-    // buildRankings returns per-bot match counts on the slice.
-    const eligible = ranking.players
-      .filter((p) => (p.matches ?? 0) >= minPlayed)
-      .slice(0, top);
-
-    const era = {
-      i,
-      endMatch: endIdx,
-      startTs: matches[0].ts,
-      endTs: matches[endIdx - 1]?.ts,
-      top: eligible.map((p) => ({
-        name: p.name, rating: p.rating, matches: p.matches,
-      })),
-    };
-    eras.push(era);
-
-    for (const p of eligible) {
-      if (!seen.has(p.name)) {
-        seen.set(p.name, { firstEra: i, appearances: [] });
-      }
-      seen.get(p.name).appearances.push({
-        era: i, rating: p.rating, matches: p.matches,
-      });
-    }
+function pickEraChampions(rankings, lineages, top, minPlayed) {
+  // Each generation = one era. Within each era, rank bots by current
+  // global rating and take the top-`top` bots that played at least
+  // `minPlayed` matches under the current rules version. Bots without
+  // a lineage record (e.g. founders not yet enrolled) are skipped.
+  const lineByName = new Map(lineages.map((b) => [b.name, b]));
+  const buckets = new Map();
+  for (const p of rankings.players) {
+    const ln = lineByName.get(p.name);
+    if (!ln) continue;
+    if ((p.matches ?? 0) < minPlayed) continue;
+    const g = ln.generation;
+    if (!buckets.has(g)) buckets.set(g, []);
+    buckets.get(g).push({
+      name: p.name,
+      rating: p.rating,
+      matches: p.matches,
+      wins: p.wins,
+      generation: g,
+    });
   }
-  return { eras, seen };
+  const eras = [];
+  const champions = new Map(); // name -> { generation, rating, matches, wins }
+  for (const g of [...buckets.keys()].sort((a, b) => a - b)) {
+    const top_ = buckets.get(g).sort((a, b) => b.rating - a.rating).slice(0, top);
+    if (!top_.length) continue;
+    eras.push({ generation: g, top: top_ });
+    for (const r of top_) champions.set(r.name, r);
+  }
+  return { eras, champions };
 }
 
 function pickPool(map, opt) {
@@ -111,46 +112,74 @@ function pickPool(map, opt) {
   return map.players ?? 5;
 }
 
+function spearman(items, keyA, keyB) {
+  // items: array of { name, ... }; keyA, keyB: numeric fields whose
+  // descending order defines a ranking. Returns Spearman rho. Ties are
+  // broken stably (the internal sort is stable in Node).
+  const N = items.length;
+  if (N < 2) return null;
+  const byA = items.slice().sort((a, b) => b[keyA] - a[keyA]);
+  const byB = items.slice().sort((a, b) => b[keyB] - a[keyB]);
+  const rA = new Map(), rB = new Map();
+  byA.forEach((r, i) => rA.set(r.name, i + 1));
+  byB.forEach((r, i) => rB.set(r.name, i + 1));
+  let d2 = 0;
+  for (const r of items) d2 += (rA.get(r.name) - rB.get(r.name)) ** 2;
+  return 1 - (6 * d2) / (N * (N * N - 1));
+}
+
 async function main() {
   const opts = parseArgs(process.argv.slice(2));
   const map = MAPS[opts.map];
   if (!map) throw new Error(`Unknown map: ${opts.map}. Choices: ${Object.keys(MAPS).join(", ")}`);
 
-  console.log(`Loading match log...`);
-  const all = await loadMatches();
-  const matches = filterCurrentVersion(all).slice().sort((a, b) => {
-    if (a.ts === b.ts) return 0;
-    return a.ts < b.ts ? -1 : 1;
-  });
-  if (matches.length < opts.intervals * 10) {
-    throw new Error(`Not enough matches (${matches.length}) to support ${opts.intervals} intervals.`);
+  console.log(`Loading rankings + lineages...`);
+  const [rankings, lineages] = await Promise.all([loadRankings(), loadLineages()]);
+  if (!rankings) throw new Error(`No rankings.json — run \`npm run rank\` first.`);
+  if (!lineages.length) throw new Error(`No lineage records — run the loop or seed lineages.json first.`);
+  console.log(`  ${rankings.players.length} players, ${lineages.length} lineage records (current: ${rankings.matchCount} matches)`);
+
+  const { eras, champions } = pickEraChampions(rankings, lineages, opts.top, opts.minPlayed);
+
+  // Pin a specific bot if requested. If it's already a champion, nothing
+  // changes; otherwise we add it with whatever lineage/rating data we
+  // have so it still gets reported in the per-era summary.
+  if (opts.pin && !champions.has(opts.pin)) {
+    const p = rankings.players.find((x) => x.name === opts.pin);
+    if (!p) throw new Error(`--pin ${opts.pin}: not in rankings.json`);
+    const ln = lineages.find((b) => b.name === opts.pin);
+    champions.set(opts.pin, {
+      name: p.name,
+      rating: p.rating,
+      matches: p.matches,
+      wins: p.wins,
+      generation: ln?.generation ?? null,
+    });
+    console.log(`Pinned ${opts.pin} into the field (gen ${ln?.generation ?? "?"}, rating ${p.rating}).`);
   }
-  console.log(`  ${matches.length} current-rules matches across ${matches[0].ts} → ${matches[matches.length - 1].ts}`);
 
-  const { eras, seen } = pickEraChampions(matches, opts.intervals, opts.top, opts.minPlayedInEra);
-
-  console.log(`\nEra champions (top ${opts.top} per era, min ${opts.minPlayedInEra} matches in era):`);
+  console.log(`\nEra champions (top ${opts.top} per generation, min ${opts.minPlayed} matches):`);
   for (const era of eras) {
-    const span = `era ${era.i}/${opts.intervals}  matches 1..${era.endMatch}  ${era.endTs}`;
-    console.log(`  ${span}`);
-    for (const p of era.top) {
-      const tag = seen.get(p.name).firstEra === era.i ? "NEW" : "   ";
-      console.log(`    [${tag}] ${String(p.rating).padStart(5)}  ${p.name.padEnd(24)} (${p.matches}m)`);
+    for (const r of era.top) {
+      const wr = r.matches ? (100 * r.wins / r.matches).toFixed(0) : "  -";
+      console.log(`  g${String(era.generation).padStart(2)}  ${String(r.rating).padStart(5)}  ${r.name.padEnd(28)}  ${r.wins}/${r.matches} (${wr}%)`);
     }
   }
 
-  const fieldNames = [...seen.keys()];
-  console.log(`\nUnique era champions: ${fieldNames.length} bots`);
-
-  // Resolve names. Use ALL_STRATEGIES so archived bots are loadable —
-  // an archived bot that was once a top-of-era is exactly what we want
-  // to bring back for the cross-era tournament.
+  // Resolve to strategy modules. Archived bots stay loadable via
+  // ALL_STRATEGIES, which is exactly what we want — historical
+  // top-of-era bots are the whole point.
   const missing = [];
   const field = [];
-  for (const name of fieldNames) {
+  const fieldMeta = new Map();
+  for (const [name, meta] of champions.entries()) {
     const s = ALL_STRATEGIES[name];
-    if (s) field.push(s);
-    else missing.push(name);
+    if (s) {
+      field.push(s);
+      fieldMeta.set(name, meta);
+    } else {
+      missing.push(name);
+    }
   }
   if (missing.length) {
     console.warn(`  WARNING: ${missing.length} bot${missing.length === 1 ? "" : "s"} unloadable — file deleted? ${missing.join(", ")}`);
@@ -160,7 +189,26 @@ async function main() {
   }
 
   const k = Math.min(pickPool(map, opts.pool), field.length);
-  console.log(`\nRunning cross-era tournament: ${opts.matches} matches, K=${k}, map=${opts.map}\n`);
+  console.log(`\nField: ${field.length} bots. Running cross-era tournament: ${opts.matches} matches, K=${k}, map=${opts.map}\n`);
+
+  // Per-pair coplay counters: pairWin[a].get(b) = number of matches
+  // where a finished above b (only meaningful when a and b were both
+  // sampled into the same lineup). Used for the pinned bot's pairwise
+  // win-rate report.
+  const pairWin = new Map();
+  const pairEnc = new Map();
+  for (const s of field) {
+    pairWin.set(s.name, new Map());
+    pairEnc.set(s.name, new Map());
+  }
+  function bumpPair(a, b, aWon) {
+    const enc = pairEnc.get(a);
+    enc.set(b, (enc.get(b) ?? 0) + 1);
+    if (aWon) {
+      const w = pairWin.get(a);
+      w.set(b, (w.get(b) ?? 0) + 1);
+    }
+  }
 
   const t0 = Date.now();
   const matchEntries = [];
@@ -172,11 +220,13 @@ async function main() {
     baseSeed: opts.seed,
     maxTicks: 4000,
     onMatch: (mi, matchResult) => {
-      // Cross-era matches go into matches.jsonl alongside loop matches.
-      // Archived bots are archived for convenience (weaker than current
-      // peers), not because their matches are from a different "era" —
-      // here, "era" tracks the bot generation count, not match count.
-      // Mixing this evidence into the global PL fit only adds data.
+      const order = matchResult.ranking.map((r) => r.strategy);
+      for (let i = 0; i < order.length; i++) {
+        for (let j = 0; j < order.length; j++) {
+          if (i === j) continue;
+          bumpPair(order[i], order[j], i < j);
+        }
+      }
       matchEntries.push(buildMatchEntry({
         map: { name: map.name, config: map.config },
         result: { ...matchResult, seed: opts.seed + mi },
@@ -190,40 +240,105 @@ async function main() {
   const dt = ((Date.now() - t0) / 1000).toFixed(1);
   console.log(`\nTournament complete in ${dt}s.\n`);
 
-  // Annotate standings with era info.
-  const annotated = result.standings.map((s) => {
-    const meta = seen.get(s.name);
+  // Annotate standings with era + global priors.
+  const annotated = result.standings.map((s, i) => {
+    const meta = fieldMeta.get(s.name);
     return {
-      ...s,
-      firstEra: meta?.firstEra ?? null,
-      appearances: meta?.appearances ?? [],
+      rank: i + 1,
+      name: s.name,
+      generation: meta?.generation ?? null,
+      crossRating: s.rating,
+      crossWinRate: +(s.winRate ?? 0).toFixed(3),
+      crossPpg: +s.pointsPerGame.toFixed(3),
+      crossPlayed: s.played,
+      crossWins: s.wins,
+      globalRating: meta?.rating ?? null,
+      globalMatches: meta?.matches ?? null,
+      globalWinRate: meta && meta.matches ? +(meta.wins / meta.matches).toFixed(3) : null,
     };
   });
 
-  console.log(`Cross-era standings (${field.length} bots, ${opts.matches} matches):`);
-  console.log(`  rank  rating  played  firstEra  bot`);
-  annotated.forEach((s, i) => {
-    const era = s.firstEra ? `e${String(s.firstEra).padStart(2)}` : "  -";
+  console.log(`Cross-era standings (sorted by cross-era rating):`);
+  console.log(`  rank  gen  xRating  xWin%  xPPG  xPlayed | gRating  gWin%  gPlayed  bot`);
+  for (const r of annotated) {
+    const xr = String(r.crossRating).padStart(5);
+    const gr = String(r.globalRating ?? "-").padStart(5);
+    const xw = (100 * r.crossWinRate).toFixed(1).padStart(5);
+    const gw = r.globalWinRate != null ? (100 * r.globalWinRate).toFixed(1).padStart(5) : "    -";
+    const ppg = r.crossPpg.toFixed(2).padStart(4);
+    const gen = r.generation != null ? `g${String(r.generation).padStart(2)}` : "  -";
     console.log(
-      `  ${String(i + 1).padStart(2)}.   ${String(s.rating).padStart(5)}  ${String(s.played).padStart(5)}  ${era}      ${s.name}`,
+      `  ${String(r.rank).padStart(2)}.   ${gen}  ${xr}   ${xw}  ${ppg}   ${String(r.crossPlayed).padStart(4)}  | ${gr}   ${gw}   ${String(r.globalMatches ?? "-").padStart(5)}  ${r.name}`,
     );
-  });
+  }
 
-  // Aggregate per-era: average rank of bots whose first era is X.
+  // Per-era summary: avg rank + rating of bots from each generation in
+  // the cross-era field. Lower avg rank = stronger; trend across
+  // generations shows real progress (or lack of it).
   const byEra = new Map();
-  annotated.forEach((s, i) => {
-    const e = s.firstEra;
-    if (e == null) return;
+  for (const r of annotated) {
+    const e = r.generation;
+    if (e == null) continue;
     if (!byEra.has(e)) byEra.set(e, []);
-    byEra.get(e).push({ name: s.name, rank: i + 1, rating: s.rating });
-  });
-  console.log(`\nAvg cross-era rank by debut era (lower = stronger; trend shows progress over time):`);
+    byEra.get(e).push(r);
+  }
+  console.log(`\nAvg cross-era rank by generation (lower = stronger):`);
   const sortedEras = [...byEra.keys()].sort((a, b) => a - b);
   for (const e of sortedEras) {
     const rows = byEra.get(e);
     const avgRank = rows.reduce((a, r) => a + r.rank, 0) / rows.length;
-    const avgRating = rows.reduce((a, r) => a + r.rating, 0) / rows.length;
-    console.log(`  era ${String(e).padStart(2)}  n=${rows.length}  avgRank=${avgRank.toFixed(1)}  avgRating=${avgRating.toFixed(0)}`);
+    const avgRating = rows.reduce((a, r) => a + r.crossRating, 0) / rows.length;
+    const avgWin = rows.reduce((a, r) => a + r.crossWinRate, 0) / rows.length;
+    console.log(`  g${String(e).padStart(2)}  n=${rows.length}  avgRank=${avgRank.toFixed(1)}  avgRating=${avgRating.toFixed(0)}  avgWin%=${(100 * avgWin).toFixed(1)}`);
+  }
+
+  // Spearman rho between cross-era rating and (a) cross-era winRate,
+  // (b) global rating. (a) tells you whether the rating tracks raw
+  // wins in this field; (b) tells you whether the global ranking
+  // agrees with the head-to-head verdict.
+  const rhoXrXw = spearman(annotated, "crossRating", "crossWinRate");
+  const annotatedWithG = annotated.filter((r) => r.globalRating != null);
+  const rhoXrG = spearman(annotatedWithG, "crossRating", "globalRating");
+  console.log(`\nSpearman rank correlations:`);
+  console.log(`  cross rating vs cross winRate : rho = ${rhoXrXw?.toFixed(3) ?? "-"}`);
+  console.log(`  cross rating vs global rating : rho = ${rhoXrG?.toFixed(3) ?? "-"}`);
+
+  // Pairwise winrate of pinned bot vs every opponent it shared a match
+  // with. This is the head-to-head answer: "in matches where both bot
+  // X and pin both played, who finished higher more often?"
+  let pinReport = null;
+  if (opts.pin) {
+    const enc = pairEnc.get(opts.pin);
+    if (enc) {
+      const rows = [];
+      for (const [opp, n] of enc.entries()) {
+        const w = pairWin.get(opts.pin).get(opp) ?? 0;
+        const meta = fieldMeta.get(opp);
+        rows.push({
+          name: opp,
+          encounters: n,
+          wins: w,
+          winRate: n ? +(w / n).toFixed(3) : 0,
+          generation: meta?.generation ?? null,
+          globalRating: meta?.rating ?? null,
+        });
+      }
+      rows.sort((a, b) => (a.generation ?? 0) - (b.generation ?? 0) || (b.globalRating ?? 0) - (a.globalRating ?? 0));
+      console.log(`\nPairwise (FFA-coplay) winrate of ${opts.pin} vs each opponent:`);
+      console.log(`  opp_gen  oppRating  enc  wins  win%   opponent`);
+      let totalEnc = 0, totalWin = 0;
+      for (const r of rows) {
+        totalEnc += r.encounters;
+        totalWin += r.wins;
+        const gen = r.generation != null ? `g${String(r.generation).padStart(2)}` : "  -";
+        console.log(
+          `  ${gen}     ${String(r.globalRating ?? "-").padStart(5)}  ${String(r.encounters).padStart(3)}  ${String(r.wins).padStart(4)}  ${(100 * r.winRate).toFixed(1).padStart(5)}  ${r.name}`,
+        );
+      }
+      const overall = totalEnc ? totalWin / totalEnc : 0;
+      console.log(`  ----  overall: ${totalWin}/${totalEnc} = ${(100 * overall).toFixed(1)}% pairwise wins across all opponents`);
+      pinReport = { rows, totalEnc, totalWin, overallWinRate: +overall.toFixed(3) };
+    }
   }
 
   await writeFile(
@@ -231,24 +346,35 @@ async function main() {
     JSON.stringify({
       generatedAt: new Date().toISOString(),
       opts,
-      logRange: { firstTs: matches[0].ts, lastTs: matches[matches.length - 1].ts, count: matches.length },
       eras,
       missing,
       standings: annotated,
+      correlations: { rhoXrXw, rhoXrG },
+      pin: opts.pin ? { name: opts.pin, ...(pinReport ?? {}) } : null,
     }, null, 2) + "\n",
     "utf8",
   );
   console.log(`\nWrote ${OUT_PATH}`);
 
   if (opts.append && matchEntries.length) {
-    console.log(`\nAppending ${matchEntries.length} matches to ${getMatchLogPath()}...`);
-    await appendMatches(matchEntries);
-    console.log(`Refitting global rankings...`);
-    const allLog = await loadMatches();
-    const currentLog = filterCurrentVersion(allLog);
-    const refreshed = buildRankings(currentLog);
-    await saveRankings(refreshed);
-    console.log(`Wrote ${getRankingsPath()} (${refreshed.players.length} players, ${refreshed.matchCount} matches).`);
+    // Persist matches into the global log + refit the global PL ranking.
+    // Skip the refit if the log was empty before this run (we'd be
+    // building a global ranking from only ~400 cross-era matches, which
+    // would clobber the real one).
+    const existingBefore = await loadMatches();
+    if (existingBefore.length === 0) {
+      console.log(`\n--append: matches.jsonl is empty; appending the ${matchEntries.length} cross-era matches but skipping global rankings refit (would clobber rankings.json with too little data).`);
+      await appendMatches(matchEntries);
+    } else {
+      console.log(`\nAppending ${matchEntries.length} matches to ${getMatchLogPath()}...`);
+      await appendMatches(matchEntries);
+      console.log(`Refitting global rankings...`);
+      const allLog = await loadMatches();
+      const currentLog = filterCurrentVersion(allLog);
+      const refreshed = buildRankings(currentLog);
+      await saveRankings(refreshed);
+      console.log(`Wrote ${getRankingsPath()} (${refreshed.players.length} players, ${refreshed.matchCount} matches).`);
+    }
   } else if (!opts.append) {
     console.log(`\n--no-append: ${matchEntries.length} cross-era matches not persisted.`);
   }

--- a/tournament/eras.json
+++ b/tournament/eras.json
@@ -1,13 +1,13 @@
 {
-  "generatedAt": "2026-05-08T06:58:38.147Z",
+  "generatedAt": "2026-05-08T12:26:50.092Z",
   "opts": {
-    "top": 3,
-    "matches": 2000,
+    "top": 1,
+    "matches": 400,
     "pool": null,
     "map": "lab1",
     "seed": 1,
     "minPlayed": 15,
-    "pin": "Conqueror_g14_8d5369",
+    "pin": "Drumline",
     "append": false
   },
   "eras": [
@@ -18,20 +18,6 @@
           "name": "Tactician",
           "rating": 875,
           "matches": 887,
-          "wins": 0,
-          "generation": 0
-        },
-        {
-          "name": "Pinwheel",
-          "rating": 848,
-          "matches": 463,
-          "wins": 1,
-          "generation": 0
-        },
-        {
-          "name": "Cluster_08",
-          "rating": 844,
-          "matches": 192,
           "wins": 0,
           "generation": 0
         }
@@ -58,20 +44,6 @@
           "matches": 351,
           "wins": 62,
           "generation": 2
-        },
-        {
-          "name": "Conqueror_g2_e0f65e",
-          "rating": 982,
-          "matches": 43,
-          "wins": 9,
-          "generation": 2
-        },
-        {
-          "name": "Conqueror_g2_e90f66",
-          "rating": 975,
-          "matches": 488,
-          "wins": 92,
-          "generation": 2
         }
       ]
     },
@@ -96,20 +68,6 @@
           "matches": 91,
           "wins": 27,
           "generation": 4
-        },
-        {
-          "name": "Conqueror_g4_3fd4ce",
-          "rating": 1057,
-          "matches": 476,
-          "wins": 149,
-          "generation": 4
-        },
-        {
-          "name": "Conqueror_g4_de5d02",
-          "rating": 1032,
-          "matches": 738,
-          "wins": 140,
-          "generation": 4
         }
       ]
     },
@@ -121,20 +79,6 @@
           "rating": 1066,
           "matches": 93,
           "wins": 22,
-          "generation": 5
-        },
-        {
-          "name": "Conqueror_g5_f15d3e",
-          "rating": 1060,
-          "matches": 1107,
-          "wins": 219,
-          "generation": 5
-        },
-        {
-          "name": "Conqueror_g5_edeed5",
-          "rating": 1049,
-          "matches": 789,
-          "wins": 131,
           "generation": 5
         }
       ]
@@ -148,20 +92,6 @@
           "matches": 566,
           "wins": 175,
           "generation": 6
-        },
-        {
-          "name": "Conqueror_g6_27c4e7",
-          "rating": 1055,
-          "matches": 1026,
-          "wins": 193,
-          "generation": 6
-        },
-        {
-          "name": "Conqueror_g6_53407c",
-          "rating": 1045,
-          "matches": 921,
-          "wins": 148,
-          "generation": 6
         }
       ]
     },
@@ -173,20 +103,6 @@
           "rating": 1056,
           "matches": 499,
           "wins": 162,
-          "generation": 7
-        },
-        {
-          "name": "Conqueror_g7_efa4e0",
-          "rating": 1052,
-          "matches": 1551,
-          "wins": 354,
-          "generation": 7
-        },
-        {
-          "name": "Conqueror_g7_31769b",
-          "rating": 1043,
-          "matches": 282,
-          "wins": 87,
           "generation": 7
         }
       ]
@@ -200,20 +116,6 @@
           "matches": 45,
           "wins": 19,
           "generation": 8
-        },
-        {
-          "name": "Conqueror_g8_5c68e4",
-          "rating": 1097,
-          "matches": 167,
-          "wins": 56,
-          "generation": 8
-        },
-        {
-          "name": "Conqueror_g8_579783",
-          "rating": 1085,
-          "matches": 251,
-          "wins": 82,
-          "generation": 8
         }
       ]
     },
@@ -225,20 +127,6 @@
           "rating": 1093,
           "matches": 25,
           "wins": 9,
-          "generation": 9
-        },
-        {
-          "name": "Conqueror_g9_469924",
-          "rating": 1062,
-          "matches": 109,
-          "wins": 30,
-          "generation": 9
-        },
-        {
-          "name": "Conqueror_g9_aa6fcf",
-          "rating": 1051,
-          "matches": 90,
-          "wins": 18,
           "generation": 9
         }
       ]
@@ -252,20 +140,6 @@
           "matches": 278,
           "wins": 65,
           "generation": 10
-        },
-        {
-          "name": "Conqueror_g10_447dc3",
-          "rating": 1063,
-          "matches": 269,
-          "wins": 81,
-          "generation": 10
-        },
-        {
-          "name": "Conqueror_g10_c1e73e",
-          "rating": 1055,
-          "matches": 84,
-          "wins": 19,
-          "generation": 10
         }
       ]
     },
@@ -277,20 +151,6 @@
           "rating": 1068,
           "matches": 103,
           "wins": 25,
-          "generation": 11
-        },
-        {
-          "name": "Conqueror_g11_755fa9",
-          "rating": 1051,
-          "matches": 1032,
-          "wins": 205,
-          "generation": 11
-        },
-        {
-          "name": "Conqueror_g11_6c48eb",
-          "rating": 1050,
-          "matches": 280,
-          "wins": 85,
           "generation": 11
         }
       ]
@@ -316,20 +176,6 @@
           "matches": 736,
           "wins": 204,
           "generation": 13
-        },
-        {
-          "name": "Conqueror_g13_8fa0f9",
-          "rating": 1040,
-          "matches": 77,
-          "wins": 15,
-          "generation": 13
-        },
-        {
-          "name": "Conqueror_g13_036b6a",
-          "rating": 1032,
-          "matches": 68,
-          "wins": 12,
-          "generation": 13
         }
       ]
     },
@@ -341,20 +187,6 @@
           "rating": 1205,
           "matches": 351,
           "wins": 131,
-          "generation": 14
-        },
-        {
-          "name": "Conqueror_g14_5ae6c0",
-          "rating": 1168,
-          "matches": 156,
-          "wins": 48,
-          "generation": 14
-        },
-        {
-          "name": "Conqueror_g14_2486d3",
-          "rating": 1141,
-          "matches": 244,
-          "wins": 72,
           "generation": 14
         }
       ]
@@ -368,20 +200,6 @@
           "matches": 51,
           "wins": 17,
           "generation": 15
-        },
-        {
-          "name": "Conqueror_g15_313179",
-          "rating": 1170,
-          "matches": 107,
-          "wins": 32,
-          "generation": 15
-        },
-        {
-          "name": "Conqueror_g15_eb52b8",
-          "rating": 1145,
-          "matches": 144,
-          "wins": 41,
-          "generation": 15
         }
       ]
     },
@@ -393,13 +211,6 @@
           "rating": 1110,
           "matches": 466,
           "wins": 111,
-          "generation": 16
-        },
-        {
-          "name": "Conqueror_g16_3f3a3d",
-          "rating": 1063,
-          "matches": 89,
-          "wins": 18,
           "generation": 16
         }
       ]
@@ -413,13 +224,6 @@
           "matches": 310,
           "wins": 77,
           "generation": 17
-        },
-        {
-          "name": "Conqueror_g17_397562",
-          "rating": 1103,
-          "matches": 420,
-          "wins": 94,
-          "generation": 17
         }
       ]
     },
@@ -431,13 +235,6 @@
           "rating": 1132,
           "matches": 443,
           "wins": 119,
-          "generation": 18
-        },
-        {
-          "name": "Conqueror_g18_7e8c2e",
-          "rating": 1086,
-          "matches": 105,
-          "wins": 23,
           "generation": 18
         }
       ]
@@ -463,20 +260,6 @@
           "matches": 141,
           "wins": 42,
           "generation": 20
-        },
-        {
-          "name": "Conqueror_g20_19eb85",
-          "rating": 1122,
-          "matches": 160,
-          "wins": 41,
-          "generation": 20
-        },
-        {
-          "name": "Conqueror_g20_f5c991",
-          "rating": 1104,
-          "matches": 222,
-          "wins": 49,
-          "generation": 20
         }
       ]
     },
@@ -497,1120 +280,490 @@
   "standings": [
     {
       "rank": 1,
-      "name": "Conqueror_g20_43253a",
-      "generation": 20,
-      "crossRating": 1040.45,
-      "crossWinRate": 0.321,
-      "crossPpg": 2.281,
-      "crossPlayed": 196,
-      "crossWins": 63,
-      "globalRating": 1151,
-      "globalMatches": 141,
-      "globalWinRate": 0.298
-    },
-    {
-      "rank": 2,
-      "name": "Conqueror_g21_e2aa5a",
-      "generation": 21,
-      "crossRating": 1028.25,
-      "crossWinRate": 0.278,
-      "crossPpg": 2.19,
-      "crossPlayed": 216,
-      "crossWins": 60,
-      "globalRating": 1095,
-      "globalMatches": 73,
-      "globalWinRate": 0.192
-    },
-    {
-      "rank": 3,
       "name": "Conqueror_g19_9533e3",
       "generation": 19,
-      "crossRating": 1027.94,
-      "crossWinRate": 0.291,
-      "crossPpg": 2.221,
-      "crossPlayed": 213,
-      "crossWins": 62,
+      "crossRating": 1054.45,
+      "crossWinRate": 0.368,
+      "crossPpg": 2.345,
+      "crossPlayed": 87,
+      "crossWins": 32,
       "globalRating": 1157,
       "globalMatches": 397,
       "globalWinRate": 0.307
     },
     {
-      "rank": 4,
-      "name": "Conqueror_g14_8d5369",
-      "generation": 14,
-      "crossRating": 1024.26,
-      "crossWinRate": 0.271,
-      "crossPpg": 2.31,
-      "crossPlayed": 210,
-      "crossWins": 57,
-      "globalRating": 1205,
-      "globalMatches": 351,
-      "globalWinRate": 0.373
-    },
-    {
-      "rank": 5,
-      "name": "Conqueror_g10_c1e73e",
-      "generation": 10,
-      "crossRating": 1023.03,
-      "crossWinRate": 0.264,
-      "crossPpg": 2.076,
-      "crossPlayed": 197,
-      "crossWins": 52,
-      "globalRating": 1055,
-      "globalMatches": 84,
-      "globalWinRate": 0.226
-    },
-    {
-      "rank": 6,
-      "name": "Conqueror_g9_aa6fcf",
-      "generation": 9,
-      "crossRating": 1021.86,
-      "crossWinRate": 0.257,
-      "crossPpg": 2.017,
-      "crossPlayed": 179,
-      "crossWins": 46,
-      "globalRating": 1051,
-      "globalMatches": 90,
-      "globalWinRate": 0.2
-    },
-    {
-      "rank": 7,
-      "name": "Conqueror_g17_397562",
-      "generation": 17,
-      "crossRating": 1021.24,
-      "crossWinRate": 0.255,
-      "crossPpg": 2.071,
-      "crossPlayed": 184,
-      "crossWins": 47,
-      "globalRating": 1103,
-      "globalMatches": 420,
-      "globalWinRate": 0.224
-    },
-    {
-      "rank": 8,
-      "name": "Conqueror_g15_eb52b8",
-      "generation": 15,
-      "crossRating": 1021.01,
-      "crossWinRate": 0.257,
-      "crossPpg": 2.134,
-      "crossPlayed": 187,
-      "crossWins": 48,
-      "globalRating": 1145,
-      "globalMatches": 144,
-      "globalWinRate": 0.285
-    },
-    {
-      "rank": 9,
-      "name": "Conqueror_g20_f5c991",
-      "generation": 20,
-      "crossRating": 1019.94,
-      "crossWinRate": 0.272,
-      "crossPpg": 2.084,
-      "crossPlayed": 191,
-      "crossWins": 52,
-      "globalRating": 1104,
-      "globalMatches": 222,
-      "globalWinRate": 0.221
-    },
-    {
-      "rank": 10,
+      "rank": 2,
       "name": "Conqueror_g15_2c15dc",
       "generation": 15,
-      "crossRating": 1019.83,
-      "crossWinRate": 0.259,
-      "crossPpg": 2.151,
-      "crossPlayed": 185,
-      "crossWins": 48,
+      "crossRating": 1030.02,
+      "crossWinRate": 0.324,
+      "crossPpg": 2.363,
+      "crossPlayed": 102,
+      "crossWins": 33,
       "globalRating": 1181,
       "globalMatches": 51,
       "globalWinRate": 0.333
     },
     {
-      "rank": 11,
-      "name": "Conqueror_g6_9eb2e4",
-      "generation": 6,
-      "crossRating": 1019.74,
-      "crossWinRate": 0.25,
-      "crossPpg": 1.865,
-      "crossPlayed": 208,
-      "crossWins": 52,
-      "globalRating": 1063,
-      "globalMatches": 566,
-      "globalWinRate": 0.309
+      "rank": 3,
+      "name": "Conqueror_g21_e2aa5a",
+      "generation": 21,
+      "crossRating": 1024.28,
+      "crossWinRate": 0.305,
+      "crossPpg": 2.256,
+      "crossPlayed": 82,
+      "crossWins": 25,
+      "globalRating": 1095,
+      "globalMatches": 73,
+      "globalWinRate": 0.192
     },
     {
-      "rank": 12,
-      "name": "Conqueror_g14_5ae6c0",
-      "generation": 14,
-      "crossRating": 1018.3,
-      "crossWinRate": 0.28,
-      "crossPpg": 2.28,
-      "crossPlayed": 189,
-      "crossWins": 53,
-      "globalRating": 1168,
-      "globalMatches": 156,
-      "globalWinRate": 0.308
-    },
-    {
-      "rank": 13,
-      "name": "Conqueror_g2_6b59e8",
-      "generation": 2,
-      "crossRating": 1017.14,
-      "crossWinRate": 0.25,
-      "crossPpg": 2.026,
-      "crossPlayed": 192,
-      "crossWins": 48,
-      "globalRating": 990,
-      "globalMatches": 351,
-      "globalWinRate": 0.177
-    },
-    {
-      "rank": 14,
-      "name": "Conqueror_g17_6d0fb0",
-      "generation": 17,
-      "crossRating": 1016.15,
-      "crossWinRate": 0.228,
-      "crossPpg": 2.01,
-      "crossPlayed": 206,
-      "crossWins": 47,
-      "globalRating": 1116,
-      "globalMatches": 310,
-      "globalWinRate": 0.248
-    },
-    {
-      "rank": 15,
-      "name": "Conqueror_g16_e79590",
-      "generation": 16,
-      "crossRating": 1015.32,
-      "crossWinRate": 0.241,
-      "crossPpg": 2.052,
-      "crossPlayed": 174,
-      "crossWins": 42,
-      "globalRating": 1110,
-      "globalMatches": 466,
-      "globalWinRate": 0.238
-    },
-    {
-      "rank": 16,
-      "name": "Conqueror_g8_579783",
-      "generation": 8,
-      "crossRating": 1015.11,
-      "crossWinRate": 0.238,
-      "crossPpg": 1.852,
-      "crossPlayed": 189,
-      "crossWins": 45,
-      "globalRating": 1085,
-      "globalMatches": 251,
-      "globalWinRate": 0.327
-    },
-    {
-      "rank": 17,
-      "name": "Conqueror_g13_8fa0f9",
-      "generation": 13,
-      "crossRating": 1010.32,
-      "crossWinRate": 0.232,
-      "crossPpg": 1.945,
-      "crossPlayed": 181,
-      "crossWins": 42,
-      "globalRating": 1040,
-      "globalMatches": 77,
-      "globalWinRate": 0.195
-    },
-    {
-      "rank": 18,
-      "name": "Conqueror_g16_3f3a3d",
-      "generation": 16,
-      "crossRating": 1009.3,
-      "crossWinRate": 0.24,
-      "crossPpg": 1.911,
-      "crossPlayed": 192,
-      "crossWins": 46,
-      "globalRating": 1063,
-      "globalMatches": 89,
-      "globalWinRate": 0.202
-    },
-    {
-      "rank": 19,
-      "name": "Conqueror_g20_19eb85",
-      "generation": 20,
-      "crossRating": 1007.87,
-      "crossWinRate": 0.238,
-      "crossPpg": 2.162,
-      "crossPlayed": 185,
-      "crossWins": 44,
-      "globalRating": 1122,
-      "globalMatches": 160,
-      "globalWinRate": 0.256
-    },
-    {
-      "rank": 20,
-      "name": "Conqueror_g14_2486d3",
-      "generation": 14,
-      "crossRating": 1006.35,
-      "crossWinRate": 0.215,
-      "crossPpg": 1.915,
-      "crossPlayed": 177,
-      "crossWins": 38,
-      "globalRating": 1141,
-      "globalMatches": 244,
-      "globalWinRate": 0.295
-    },
-    {
-      "rank": 21,
-      "name": "Conqueror_g8_5c68e4",
-      "generation": 8,
-      "crossRating": 1006.23,
-      "crossWinRate": 0.211,
-      "crossPpg": 1.873,
-      "crossPlayed": 204,
-      "crossWins": 43,
-      "globalRating": 1097,
-      "globalMatches": 167,
-      "globalWinRate": 0.335
-    },
-    {
-      "rank": 22,
-      "name": "Conqueror_g18_7e8c2e",
-      "generation": 18,
-      "crossRating": 1005.55,
-      "crossWinRate": 0.229,
-      "crossPpg": 2.03,
-      "crossPlayed": 201,
-      "crossWins": 46,
-      "globalRating": 1086,
-      "globalMatches": 105,
-      "globalWinRate": 0.219
-    },
-    {
-      "rank": 23,
-      "name": "Conqueror_g9_01de66",
-      "generation": 9,
-      "crossRating": 1005.36,
-      "crossWinRate": 0.212,
-      "crossPpg": 1.788,
-      "crossPlayed": 170,
-      "crossWins": 36,
-      "globalRating": 1093,
-      "globalMatches": 25,
-      "globalWinRate": 0.36
-    },
-    {
-      "rank": 24,
-      "name": "Conqueror_g18_6a26b3",
-      "generation": 18,
-      "crossRating": 1004.1,
-      "crossWinRate": 0.2,
-      "crossPpg": 2.018,
-      "crossPlayed": 165,
-      "crossWins": 33,
-      "globalRating": 1132,
-      "globalMatches": 443,
-      "globalWinRate": 0.269
-    },
-    {
-      "rank": 25,
-      "name": "Conqueror_g9_469924",
-      "generation": 9,
-      "crossRating": 1003.87,
-      "crossWinRate": 0.215,
-      "crossPpg": 1.994,
-      "crossPlayed": 177,
-      "crossWins": 38,
-      "globalRating": 1062,
-      "globalMatches": 109,
-      "globalWinRate": 0.275
-    },
-    {
-      "rank": 26,
-      "name": "Conqueror_g5_edeed5",
-      "generation": 5,
-      "crossRating": 1003.59,
-      "crossWinRate": 0.203,
-      "crossPpg": 1.976,
-      "crossPlayed": 207,
-      "crossWins": 42,
-      "globalRating": 1049,
-      "globalMatches": 789,
-      "globalWinRate": 0.166
-    },
-    {
-      "rank": 27,
-      "name": "Conqueror_g15_313179",
-      "generation": 15,
-      "crossRating": 1003.24,
-      "crossWinRate": 0.228,
-      "crossPpg": 2.114,
-      "crossPlayed": 184,
-      "crossWins": 42,
-      "globalRating": 1170,
-      "globalMatches": 107,
-      "globalWinRate": 0.299
-    },
-    {
-      "rank": 28,
-      "name": "Conqueror_g4_3fd4ce",
-      "generation": 4,
-      "crossRating": 1002.06,
-      "crossWinRate": 0.202,
-      "crossPpg": 1.852,
-      "crossPlayed": 183,
-      "crossWins": 37,
-      "globalRating": 1057,
-      "globalMatches": 476,
-      "globalWinRate": 0.313
-    },
-    {
-      "rank": 29,
-      "name": "Conqueror_g12_f23241",
-      "generation": 12,
-      "crossRating": 1001.95,
-      "crossWinRate": 0.18,
-      "crossPpg": 1.938,
-      "crossPlayed": 194,
-      "crossWins": 35,
-      "globalRating": 1068,
-      "globalMatches": 787,
-      "globalWinRate": 0.22
-    },
-    {
-      "rank": 30,
+      "rank": 4,
       "name": "Conqueror_g11_224717",
       "generation": 11,
-      "crossRating": 1001.73,
-      "crossWinRate": 0.196,
-      "crossPpg": 1.871,
-      "crossPlayed": 194,
-      "crossWins": 38,
+      "crossRating": 1022.47,
+      "crossWinRate": 0.292,
+      "crossPpg": 1.888,
+      "crossPlayed": 89,
+      "crossWins": 26,
       "globalRating": 1068,
       "globalMatches": 103,
       "globalWinRate": 0.243
     },
     {
-      "rank": 31,
-      "name": "Conqueror_g13_036b6a",
-      "generation": 13,
-      "crossRating": 1001.37,
-      "crossWinRate": 0.203,
-      "crossPpg": 1.92,
-      "crossPlayed": 187,
-      "crossWins": 38,
-      "globalRating": 1032,
-      "globalMatches": 68,
-      "globalWinRate": 0.176
+      "rank": 5,
+      "name": "Drumline",
+      "generation": null,
+      "crossRating": 1018.12,
+      "crossWinRate": 0.25,
+      "crossPpg": 2.292,
+      "crossPlayed": 96,
+      "crossWins": 24,
+      "globalRating": null,
+      "globalMatches": 0,
+      "globalWinRate": null
     },
     {
-      "rank": 32,
-      "name": "Conqueror_g7_efa4e0",
-      "generation": 7,
-      "crossRating": 1000.77,
-      "crossWinRate": 0.209,
-      "crossPpg": 1.895,
-      "crossPlayed": 172,
-      "crossWins": 36,
-      "globalRating": 1052,
-      "globalMatches": 1551,
-      "globalWinRate": 0.228
+      "rank": 6,
+      "name": "Conqueror_g14_8d5369",
+      "generation": 14,
+      "crossRating": 1016.69,
+      "crossWinRate": 0.263,
+      "crossPpg": 2.221,
+      "crossPlayed": 95,
+      "crossWins": 25,
+      "globalRating": 1205,
+      "globalMatches": 351,
+      "globalWinRate": 0.373
     },
     {
-      "rank": 33,
-      "name": "Conqueror_g4_de5d02",
-      "generation": 4,
-      "crossRating": 998.74,
-      "crossWinRate": 0.19,
-      "crossPpg": 1.722,
-      "crossPlayed": 205,
-      "crossWins": 39,
-      "globalRating": 1032,
-      "globalMatches": 738,
-      "globalWinRate": 0.19
-    },
-    {
-      "rank": 34,
+      "rank": 7,
       "name": "Conqueror_g4_be92c1",
       "generation": 4,
-      "crossRating": 996.54,
-      "crossWinRate": 0.185,
-      "crossPpg": 1.951,
-      "crossPlayed": 184,
-      "crossWins": 34,
+      "crossRating": 1013.64,
+      "crossWinRate": 0.206,
+      "crossPpg": 1.784,
+      "crossPlayed": 97,
+      "crossWins": 20,
       "globalRating": 1079,
       "globalMatches": 91,
       "globalWinRate": 0.297
     },
     {
-      "rank": 35,
-      "name": "Conqueror_g10_447dc3",
-      "generation": 10,
-      "crossRating": 995.4,
-      "crossWinRate": 0.196,
-      "crossPpg": 1.799,
-      "crossPlayed": 184,
-      "crossWins": 36,
-      "globalRating": 1063,
-      "globalMatches": 269,
-      "globalWinRate": 0.301
-    },
-    {
-      "rank": 36,
-      "name": "Conqueror_g2_e0f65e",
-      "generation": 2,
-      "crossRating": 995.18,
-      "crossWinRate": 0.192,
-      "crossPpg": 1.86,
-      "crossPlayed": 172,
-      "crossWins": 33,
-      "globalRating": 982,
-      "globalMatches": 43,
-      "globalWinRate": 0.209
-    },
-    {
-      "rank": 37,
-      "name": "Conqueror_g6_27c4e7",
-      "generation": 6,
-      "crossRating": 995.12,
-      "crossWinRate": 0.198,
-      "crossPpg": 1.846,
-      "crossPlayed": 182,
-      "crossWins": 36,
-      "globalRating": 1055,
-      "globalMatches": 1026,
-      "globalWinRate": 0.188
-    },
-    {
-      "rank": 38,
-      "name": "Conqueror_g2_e90f66",
-      "generation": 2,
-      "crossRating": 994.92,
-      "crossWinRate": 0.176,
-      "crossPpg": 1.78,
-      "crossPlayed": 205,
-      "crossWins": 36,
-      "globalRating": 975,
-      "globalMatches": 488,
-      "globalWinRate": 0.189
-    },
-    {
-      "rank": 39,
+      "rank": 8,
       "name": "Conqueror_g13_b41df9",
       "generation": 13,
-      "crossRating": 994.89,
-      "crossWinRate": 0.174,
-      "crossPpg": 1.878,
-      "crossPlayed": 172,
-      "crossWins": 30,
+      "crossRating": 1011.83,
+      "crossWinRate": 0.218,
+      "crossPpg": 2.161,
+      "crossPlayed": 87,
+      "crossWins": 19,
       "globalRating": 1124,
       "globalMatches": 736,
       "globalWinRate": 0.277
     },
     {
-      "rank": 40,
-      "name": "Conqueror_g6_53407c",
-      "generation": 6,
-      "crossRating": 992.83,
-      "crossWinRate": 0.174,
-      "crossPpg": 1.764,
-      "crossPlayed": 195,
-      "crossWins": 34,
-      "globalRating": 1045,
-      "globalMatches": 921,
-      "globalWinRate": 0.161
+      "rank": 9,
+      "name": "Conqueror_g17_6d0fb0",
+      "generation": 17,
+      "crossRating": 1009.63,
+      "crossWinRate": 0.203,
+      "crossPpg": 1.784,
+      "crossPlayed": 74,
+      "crossWins": 15,
+      "globalRating": 1116,
+      "globalMatches": 310,
+      "globalWinRate": 0.248
     },
     {
-      "rank": 41,
-      "name": "Conqueror_g7_31769b",
-      "generation": 7,
-      "crossRating": 988.82,
-      "crossWinRate": 0.172,
-      "crossPpg": 1.813,
-      "crossPlayed": 192,
-      "crossWins": 33,
-      "globalRating": 1043,
-      "globalMatches": 282,
-      "globalWinRate": 0.309
+      "rank": 10,
+      "name": "Conqueror_g20_43253a",
+      "generation": 20,
+      "crossRating": 1002.47,
+      "crossWinRate": 0.215,
+      "crossPpg": 2.177,
+      "crossPlayed": 79,
+      "crossWins": 17,
+      "globalRating": 1151,
+      "globalMatches": 141,
+      "globalWinRate": 0.298
     },
     {
-      "rank": 42,
-      "name": "Conqueror_g11_6c48eb",
-      "generation": 11,
-      "crossRating": 986.12,
-      "crossWinRate": 0.165,
-      "crossPpg": 1.797,
-      "crossPlayed": 182,
-      "crossWins": 30,
-      "globalRating": 1050,
-      "globalMatches": 280,
-      "globalWinRate": 0.304
+      "rank": 11,
+      "name": "Conqueror_g12_f23241",
+      "generation": 12,
+      "crossRating": 1000.68,
+      "crossWinRate": 0.198,
+      "crossPpg": 1.868,
+      "crossPlayed": 91,
+      "crossWins": 18,
+      "globalRating": 1068,
+      "globalMatches": 787,
+      "globalWinRate": 0.22
     },
     {
-      "rank": 43,
+      "rank": 12,
       "name": "Conqueror_g3_be9a58",
       "generation": 3,
-      "crossRating": 986,
-      "crossWinRate": 0.169,
-      "crossPpg": 1.842,
-      "crossPlayed": 177,
-      "crossWins": 30,
+      "crossRating": 999.64,
+      "crossWinRate": 0.193,
+      "crossPpg": 1.784,
+      "crossPlayed": 88,
+      "crossWins": 17,
       "globalRating": 1026,
       "globalMatches": 350,
       "globalWinRate": 0.251
     },
     {
-      "rank": 44,
-      "name": "Conqueror_g5_3087ea",
-      "generation": 5,
-      "crossRating": 985.75,
-      "crossWinRate": 0.155,
-      "crossPpg": 1.818,
-      "crossPlayed": 187,
-      "crossWins": 29,
-      "globalRating": 1066,
-      "globalMatches": 93,
-      "globalWinRate": 0.237
-    },
-    {
-      "rank": 45,
+      "rank": 13,
       "name": "Conqueror_g7_3b651e",
       "generation": 7,
-      "crossRating": 985.2,
-      "crossWinRate": 0.158,
-      "crossPpg": 1.758,
-      "crossPlayed": 190,
-      "crossWins": 30,
+      "crossRating": 998.31,
+      "crossWinRate": 0.16,
+      "crossPpg": 1.723,
+      "crossPlayed": 94,
+      "crossWins": 15,
       "globalRating": 1056,
       "globalMatches": 499,
       "globalWinRate": 0.325
     },
     {
-      "rank": 46,
+      "rank": 14,
+      "name": "Conqueror_g18_6a26b3",
+      "generation": 18,
+      "crossRating": 998.19,
+      "crossWinRate": 0.182,
+      "crossPpg": 1.828,
+      "crossPlayed": 99,
+      "crossWins": 18,
+      "globalRating": 1132,
+      "globalMatches": 443,
+      "globalWinRate": 0.269
+    },
+    {
+      "rank": 15,
+      "name": "Conqueror_g9_01de66",
+      "generation": 9,
+      "crossRating": 997.48,
+      "crossWinRate": 0.188,
+      "crossPpg": 1.792,
+      "crossPlayed": 96,
+      "crossWins": 18,
+      "globalRating": 1093,
+      "globalMatches": 25,
+      "globalWinRate": 0.36
+    },
+    {
+      "rank": 16,
+      "name": "Conqueror_g16_e79590",
+      "generation": 16,
+      "crossRating": 996.62,
+      "crossWinRate": 0.187,
+      "crossPpg": 1.827,
+      "crossPlayed": 75,
+      "crossWins": 14,
+      "globalRating": 1110,
+      "globalMatches": 466,
+      "globalWinRate": 0.238
+    },
+    {
+      "rank": 17,
+      "name": "Conqueror_g6_9eb2e4",
+      "generation": 6,
+      "crossRating": 994.54,
+      "crossWinRate": 0.132,
+      "crossPpg": 1.763,
+      "crossPlayed": 76,
+      "crossWins": 10,
+      "globalRating": 1063,
+      "globalMatches": 566,
+      "globalWinRate": 0.309
+    },
+    {
+      "rank": 18,
       "name": "Conqueror_g8_82d39b",
       "generation": 8,
-      "crossRating": 984.75,
-      "crossWinRate": 0.168,
-      "crossPpg": 1.684,
-      "crossPlayed": 190,
-      "crossWins": 32,
+      "crossRating": 989.98,
+      "crossWinRate": 0.185,
+      "crossPpg": 1.793,
+      "crossPlayed": 92,
+      "crossWins": 17,
       "globalRating": 1132,
       "globalMatches": 45,
       "globalWinRate": 0.422
     },
     {
-      "rank": 47,
-      "name": "Conqueror_g11_755fa9",
-      "generation": 11,
-      "crossRating": 984.39,
-      "crossWinRate": 0.161,
-      "crossPpg": 1.785,
-      "crossPlayed": 186,
-      "crossWins": 30,
-      "globalRating": 1051,
-      "globalMatches": 1032,
-      "globalWinRate": 0.199
+      "rank": 19,
+      "name": "Conqueror_g2_6b59e8",
+      "generation": 2,
+      "crossRating": 984.8,
+      "crossWinRate": 0.152,
+      "crossPpg": 1.861,
+      "crossPlayed": 79,
+      "crossWins": 12,
+      "globalRating": 990,
+      "globalMatches": 351,
+      "globalWinRate": 0.177
     },
     {
-      "rank": 48,
-      "name": "Conqueror_g5_f15d3e",
-      "generation": 5,
-      "crossRating": 978.15,
-      "crossWinRate": 0.145,
-      "crossPpg": 1.737,
-      "crossPlayed": 186,
-      "crossWins": 27,
-      "globalRating": 1060,
-      "globalMatches": 1107,
-      "globalWinRate": 0.198
-    },
-    {
-      "rank": 49,
+      "rank": 20,
       "name": "Conqueror_g10_34ca94",
       "generation": 10,
-      "crossRating": 972.23,
-      "crossWinRate": 0.131,
-      "crossPpg": 1.623,
-      "crossPlayed": 183,
-      "crossWins": 24,
+      "crossRating": 979.51,
+      "crossWinRate": 0.171,
+      "crossPpg": 1.78,
+      "crossPlayed": 82,
+      "crossWins": 14,
       "globalRating": 1072,
       "globalMatches": 278,
       "globalWinRate": 0.234
     },
     {
-      "rank": 50,
-      "name": "Cluster_08",
-      "generation": 0,
-      "crossRating": 942.95,
-      "crossWinRate": 0,
-      "crossPpg": 3,
-      "crossPlayed": 181,
-      "crossWins": 0,
-      "globalRating": 844,
-      "globalMatches": 192,
-      "globalWinRate": 0
+      "rank": 21,
+      "name": "Conqueror_g5_3087ea",
+      "generation": 5,
+      "crossRating": 974.52,
+      "crossWinRate": 0.143,
+      "crossPpg": 1.844,
+      "crossPlayed": 77,
+      "crossWins": 11,
+      "globalRating": 1066,
+      "globalMatches": 93,
+      "globalWinRate": 0.237
     },
     {
-      "rank": 51,
-      "name": "Phalanx_g1_5b920f",
-      "generation": 1,
-      "crossRating": 942.31,
-      "crossWinRate": 0,
-      "crossPpg": 2.946,
-      "crossPlayed": 186,
-      "crossWins": 0,
-      "globalRating": 819,
-      "globalMatches": 55,
-      "globalWinRate": 0
-    },
-    {
-      "rank": 52,
-      "name": "Pinwheel",
-      "generation": 0,
-      "crossRating": 939.39,
-      "crossWinRate": 0,
-      "crossPpg": 2.829,
-      "crossPlayed": 181,
-      "crossWins": 0,
-      "globalRating": 848,
-      "globalMatches": 463,
-      "globalWinRate": 0.002
-    },
-    {
-      "rank": 53,
+      "rank": 22,
       "name": "Tactician",
       "generation": 0,
-      "crossRating": 937.08,
+      "crossRating": 942.71,
       "crossWinRate": 0,
-      "crossPpg": 1.921,
-      "crossPlayed": 191,
+      "crossPpg": 1.843,
+      "crossPlayed": 83,
       "crossWins": 0,
       "globalRating": 875,
       "globalMatches": 887,
       "globalWinRate": 0
+    },
+    {
+      "rank": 23,
+      "name": "Phalanx_g1_5b920f",
+      "generation": 1,
+      "crossRating": 939.42,
+      "crossWinRate": 0,
+      "crossPpg": 3,
+      "crossPlayed": 80,
+      "crossWins": 0,
+      "globalRating": 819,
+      "globalMatches": 55,
+      "globalWinRate": 0
     }
   ],
   "correlations": {
-    "rhoXrXw": 0.9800032252862442,
-    "rhoXrG": 0.5853894533139816
+    "rhoXrXw": 0.958498023715415,
+    "rhoXrG": 0.637492941840768
   },
   "pin": {
-    "name": "Conqueror_g14_8d5369",
+    "name": "Drumline",
     "rows": [
       {
         "name": "Tactician",
-        "encounters": 12,
-        "wins": 9,
-        "winRate": 0.75,
+        "encounters": 14,
+        "wins": 8,
+        "winRate": 0.571,
         "generation": 0,
         "globalRating": 875
       },
       {
-        "name": "Pinwheel",
-        "encounters": 18,
-        "wins": 6,
-        "winRate": 0.333,
-        "generation": 0,
-        "globalRating": 848
-      },
-      {
-        "name": "Cluster_08",
-        "encounters": 17,
-        "wins": 7,
-        "winRate": 0.412,
-        "generation": 0,
-        "globalRating": 844
-      },
-      {
         "name": "Phalanx_g1_5b920f",
-        "encounters": 14,
-        "wins": 7,
-        "winRate": 0.5,
+        "encounters": 16,
+        "wins": 6,
+        "winRate": 0.375,
         "generation": 1,
         "globalRating": 819
       },
       {
         "name": "Conqueror_g2_6b59e8",
-        "encounters": 22,
-        "wins": 14,
-        "winRate": 0.636,
+        "encounters": 21,
+        "wins": 11,
+        "winRate": 0.524,
         "generation": 2,
         "globalRating": 990
       },
       {
-        "name": "Conqueror_g2_e0f65e",
-        "encounters": 11,
-        "wins": 7,
-        "winRate": 0.636,
-        "generation": 2,
-        "globalRating": 982
-      },
-      {
-        "name": "Conqueror_g2_e90f66",
-        "encounters": 17,
-        "wins": 12,
-        "winRate": 0.706,
-        "generation": 2,
-        "globalRating": 975
-      },
-      {
         "name": "Conqueror_g3_be9a58",
-        "encounters": 21,
-        "wins": 14,
-        "winRate": 0.667,
+        "encounters": 18,
+        "wins": 10,
+        "winRate": 0.556,
         "generation": 3,
         "globalRating": 1026
       },
       {
         "name": "Conqueror_g4_be92c1",
-        "encounters": 14,
-        "wins": 7,
-        "winRate": 0.5,
+        "encounters": 19,
+        "wins": 10,
+        "winRate": 0.526,
         "generation": 4,
         "globalRating": 1079
       },
       {
-        "name": "Conqueror_g4_3fd4ce",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
-        "generation": 4,
-        "globalRating": 1057
-      },
-      {
-        "name": "Conqueror_g4_de5d02",
-        "encounters": 22,
-        "wins": 11,
-        "winRate": 0.5,
-        "generation": 4,
-        "globalRating": 1032
-      },
-      {
         "name": "Conqueror_g5_3087ea",
-        "encounters": 16,
-        "wins": 7,
-        "winRate": 0.438,
+        "encounters": 17,
+        "wins": 11,
+        "winRate": 0.647,
         "generation": 5,
         "globalRating": 1066
       },
       {
-        "name": "Conqueror_g5_f15d3e",
-        "encounters": 15,
-        "wins": 10,
-        "winRate": 0.667,
-        "generation": 5,
-        "globalRating": 1060
-      },
-      {
-        "name": "Conqueror_g5_edeed5",
-        "encounters": 19,
-        "wins": 13,
-        "winRate": 0.684,
-        "generation": 5,
-        "globalRating": 1049
-      },
-      {
         "name": "Conqueror_g6_9eb2e4",
-        "encounters": 12,
-        "wins": 8,
-        "winRate": 0.667,
+        "encounters": 13,
+        "wins": 7,
+        "winRate": 0.538,
         "generation": 6,
         "globalRating": 1063
       },
       {
-        "name": "Conqueror_g6_27c4e7",
-        "encounters": 9,
-        "wins": 8,
-        "winRate": 0.889,
-        "generation": 6,
-        "globalRating": 1055
-      },
-      {
-        "name": "Conqueror_g6_53407c",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
-        "generation": 6,
-        "globalRating": 1045
-      },
-      {
         "name": "Conqueror_g7_3b651e",
-        "encounters": 15,
-        "wins": 9,
-        "winRate": 0.6,
+        "encounters": 18,
+        "wins": 14,
+        "winRate": 0.778,
         "generation": 7,
         "globalRating": 1056
       },
       {
-        "name": "Conqueror_g7_efa4e0",
-        "encounters": 18,
-        "wins": 9,
-        "winRate": 0.5,
-        "generation": 7,
-        "globalRating": 1052
-      },
-      {
-        "name": "Conqueror_g7_31769b",
-        "encounters": 13,
-        "wins": 6,
-        "winRate": 0.462,
-        "generation": 7,
-        "globalRating": 1043
-      },
-      {
         "name": "Conqueror_g8_82d39b",
-        "encounters": 18,
-        "wins": 13,
-        "winRate": 0.722,
+        "encounters": 15,
+        "wins": 9,
+        "winRate": 0.6,
         "generation": 8,
         "globalRating": 1132
       },
       {
-        "name": "Conqueror_g8_5c68e4",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
-        "generation": 8,
-        "globalRating": 1097
-      },
-      {
-        "name": "Conqueror_g8_579783",
-        "encounters": 10,
-        "wins": 6,
-        "winRate": 0.6,
-        "generation": 8,
-        "globalRating": 1085
-      },
-      {
         "name": "Conqueror_g9_01de66",
-        "encounters": 18,
-        "wins": 14,
-        "winRate": 0.778,
+        "encounters": 19,
+        "wins": 10,
+        "winRate": 0.526,
         "generation": 9,
         "globalRating": 1093
       },
       {
-        "name": "Conqueror_g9_469924",
-        "encounters": 16,
-        "wins": 13,
-        "winRate": 0.813,
-        "generation": 9,
-        "globalRating": 1062
-      },
-      {
-        "name": "Conqueror_g9_aa6fcf",
-        "encounters": 14,
-        "wins": 6,
-        "winRate": 0.429,
-        "generation": 9,
-        "globalRating": 1051
-      },
-      {
         "name": "Conqueror_g10_34ca94",
-        "encounters": 12,
+        "encounters": 18,
         "wins": 9,
-        "winRate": 0.75,
+        "winRate": 0.5,
         "generation": 10,
         "globalRating": 1072
       },
       {
-        "name": "Conqueror_g10_447dc3",
-        "encounters": 13,
-        "wins": 8,
-        "winRate": 0.615,
-        "generation": 10,
-        "globalRating": 1063
-      },
-      {
-        "name": "Conqueror_g10_c1e73e",
-        "encounters": 22,
-        "wins": 12,
-        "winRate": 0.545,
-        "generation": 10,
-        "globalRating": 1055
-      },
-      {
         "name": "Conqueror_g11_224717",
-        "encounters": 17,
-        "wins": 7,
-        "winRate": 0.412,
+        "encounters": 19,
+        "wins": 15,
+        "winRate": 0.789,
         "generation": 11,
         "globalRating": 1068
       },
       {
-        "name": "Conqueror_g11_755fa9",
-        "encounters": 10,
-        "wins": 4,
-        "winRate": 0.4,
-        "generation": 11,
-        "globalRating": 1051
-      },
-      {
-        "name": "Conqueror_g11_6c48eb",
-        "encounters": 13,
-        "wins": 6,
-        "winRate": 0.462,
-        "generation": 11,
-        "globalRating": 1050
-      },
-      {
         "name": "Conqueror_g12_f23241",
-        "encounters": 20,
-        "wins": 13,
-        "winRate": 0.65,
+        "encounters": 24,
+        "wins": 15,
+        "winRate": 0.625,
         "generation": 12,
         "globalRating": 1068
       },
       {
         "name": "Conqueror_g13_b41df9",
-        "encounters": 15,
-        "wins": 8,
-        "winRate": 0.533,
+        "encounters": 18,
+        "wins": 7,
+        "winRate": 0.389,
         "generation": 13,
         "globalRating": 1124
       },
       {
-        "name": "Conqueror_g13_8fa0f9",
-        "encounters": 12,
-        "wins": 7,
-        "winRate": 0.583,
-        "generation": 13,
-        "globalRating": 1040
-      },
-      {
-        "name": "Conqueror_g13_036b6a",
-        "encounters": 16,
-        "wins": 12,
-        "winRate": 0.75,
-        "generation": 13,
-        "globalRating": 1032
-      },
-      {
-        "name": "Conqueror_g14_5ae6c0",
-        "encounters": 18,
-        "wins": 13,
-        "winRate": 0.722,
-        "generation": 14,
-        "globalRating": 1168
-      },
-      {
-        "name": "Conqueror_g14_2486d3",
-        "encounters": 13,
+        "name": "Conqueror_g14_8d5369",
+        "encounters": 19,
         "wins": 8,
-        "winRate": 0.615,
+        "winRate": 0.421,
         "generation": 14,
-        "globalRating": 1141
+        "globalRating": 1205
       },
       {
         "name": "Conqueror_g15_2c15dc",
-        "encounters": 18,
-        "wins": 8,
-        "winRate": 0.444,
+        "encounters": 15,
+        "wins": 10,
+        "winRate": 0.667,
         "generation": 15,
         "globalRating": 1181
       },
       {
-        "name": "Conqueror_g15_313179",
-        "encounters": 22,
-        "wins": 11,
-        "winRate": 0.5,
-        "generation": 15,
-        "globalRating": 1170
-      },
-      {
-        "name": "Conqueror_g15_eb52b8",
-        "encounters": 15,
-        "wins": 4,
-        "winRate": 0.267,
-        "generation": 15,
-        "globalRating": 1145
-      },
-      {
         "name": "Conqueror_g16_e79590",
-        "encounters": 17,
+        "encounters": 15,
         "wins": 10,
-        "winRate": 0.588,
+        "winRate": 0.667,
         "generation": 16,
         "globalRating": 1110
       },
       {
-        "name": "Conqueror_g16_3f3a3d",
-        "encounters": 16,
-        "wins": 11,
-        "winRate": 0.688,
-        "generation": 16,
-        "globalRating": 1063
-      },
-      {
         "name": "Conqueror_g17_6d0fb0",
-        "encounters": 23,
-        "wins": 12,
-        "winRate": 0.522,
+        "encounters": 13,
+        "wins": 8,
+        "winRate": 0.615,
         "generation": 17,
         "globalRating": 1116
       },
       {
-        "name": "Conqueror_g17_397562",
-        "encounters": 13,
-        "wins": 5,
-        "winRate": 0.385,
-        "generation": 17,
-        "globalRating": 1103
-      },
-      {
         "name": "Conqueror_g18_6a26b3",
-        "encounters": 11,
-        "wins": 6,
-        "winRate": 0.545,
+        "encounters": 21,
+        "wins": 11,
+        "winRate": 0.524,
         "generation": 18,
         "globalRating": 1132
       },
       {
-        "name": "Conqueror_g18_7e8c2e",
-        "encounters": 19,
-        "wins": 13,
-        "winRate": 0.684,
-        "generation": 18,
-        "globalRating": 1086
-      },
-      {
         "name": "Conqueror_g19_9533e3",
         "encounters": 20,
-        "wins": 10,
-        "winRate": 0.5,
+        "wins": 12,
+        "winRate": 0.6,
         "generation": 19,
         "globalRating": 1157
       },
       {
         "name": "Conqueror_g20_43253a",
-        "encounters": 19,
+        "encounters": 17,
         "wins": 10,
-        "winRate": 0.526,
+        "winRate": 0.588,
         "generation": 20,
         "globalRating": 1151
       },
       {
-        "name": "Conqueror_g20_19eb85",
-        "encounters": 15,
-        "wins": 7,
-        "winRate": 0.467,
-        "generation": 20,
-        "globalRating": 1122
-      },
-      {
-        "name": "Conqueror_g20_f5c991",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
-        "generation": 20,
-        "globalRating": 1104
-      },
-      {
         "name": "Conqueror_g21_e2aa5a",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
+        "encounters": 15,
+        "wins": 9,
+        "winRate": 0.6,
         "generation": 21,
         "globalRating": 1095
       }
     ],
-    "totalEnc": 840,
-    "totalWin": 485,
-    "overallWinRate": 0.577
+    "totalEnc": 384,
+    "totalWin": 220,
+    "overallWinRate": 0.573
   }
 }

--- a/tournament/eras.json
+++ b/tournament/eras.json
@@ -1,8 +1,8 @@
 {
-  "generatedAt": "2026-05-08T06:36:40.758Z",
+  "generatedAt": "2026-05-08T06:58:38.147Z",
   "opts": {
-    "top": 1,
-    "matches": 400,
+    "top": 3,
+    "matches": 2000,
     "pool": null,
     "map": "lab1",
     "seed": 1,
@@ -18,6 +18,20 @@
           "name": "Tactician",
           "rating": 875,
           "matches": 887,
+          "wins": 0,
+          "generation": 0
+        },
+        {
+          "name": "Pinwheel",
+          "rating": 848,
+          "matches": 463,
+          "wins": 1,
+          "generation": 0
+        },
+        {
+          "name": "Cluster_08",
+          "rating": 844,
+          "matches": 192,
           "wins": 0,
           "generation": 0
         }
@@ -44,6 +58,20 @@
           "matches": 351,
           "wins": 62,
           "generation": 2
+        },
+        {
+          "name": "Conqueror_g2_e0f65e",
+          "rating": 982,
+          "matches": 43,
+          "wins": 9,
+          "generation": 2
+        },
+        {
+          "name": "Conqueror_g2_e90f66",
+          "rating": 975,
+          "matches": 488,
+          "wins": 92,
+          "generation": 2
         }
       ]
     },
@@ -68,6 +96,20 @@
           "matches": 91,
           "wins": 27,
           "generation": 4
+        },
+        {
+          "name": "Conqueror_g4_3fd4ce",
+          "rating": 1057,
+          "matches": 476,
+          "wins": 149,
+          "generation": 4
+        },
+        {
+          "name": "Conqueror_g4_de5d02",
+          "rating": 1032,
+          "matches": 738,
+          "wins": 140,
+          "generation": 4
         }
       ]
     },
@@ -79,6 +121,20 @@
           "rating": 1066,
           "matches": 93,
           "wins": 22,
+          "generation": 5
+        },
+        {
+          "name": "Conqueror_g5_f15d3e",
+          "rating": 1060,
+          "matches": 1107,
+          "wins": 219,
+          "generation": 5
+        },
+        {
+          "name": "Conqueror_g5_edeed5",
+          "rating": 1049,
+          "matches": 789,
+          "wins": 131,
           "generation": 5
         }
       ]
@@ -92,6 +148,20 @@
           "matches": 566,
           "wins": 175,
           "generation": 6
+        },
+        {
+          "name": "Conqueror_g6_27c4e7",
+          "rating": 1055,
+          "matches": 1026,
+          "wins": 193,
+          "generation": 6
+        },
+        {
+          "name": "Conqueror_g6_53407c",
+          "rating": 1045,
+          "matches": 921,
+          "wins": 148,
+          "generation": 6
         }
       ]
     },
@@ -103,6 +173,20 @@
           "rating": 1056,
           "matches": 499,
           "wins": 162,
+          "generation": 7
+        },
+        {
+          "name": "Conqueror_g7_efa4e0",
+          "rating": 1052,
+          "matches": 1551,
+          "wins": 354,
+          "generation": 7
+        },
+        {
+          "name": "Conqueror_g7_31769b",
+          "rating": 1043,
+          "matches": 282,
+          "wins": 87,
           "generation": 7
         }
       ]
@@ -116,6 +200,20 @@
           "matches": 45,
           "wins": 19,
           "generation": 8
+        },
+        {
+          "name": "Conqueror_g8_5c68e4",
+          "rating": 1097,
+          "matches": 167,
+          "wins": 56,
+          "generation": 8
+        },
+        {
+          "name": "Conqueror_g8_579783",
+          "rating": 1085,
+          "matches": 251,
+          "wins": 82,
+          "generation": 8
         }
       ]
     },
@@ -127,6 +225,20 @@
           "rating": 1093,
           "matches": 25,
           "wins": 9,
+          "generation": 9
+        },
+        {
+          "name": "Conqueror_g9_469924",
+          "rating": 1062,
+          "matches": 109,
+          "wins": 30,
+          "generation": 9
+        },
+        {
+          "name": "Conqueror_g9_aa6fcf",
+          "rating": 1051,
+          "matches": 90,
+          "wins": 18,
           "generation": 9
         }
       ]
@@ -140,6 +252,20 @@
           "matches": 278,
           "wins": 65,
           "generation": 10
+        },
+        {
+          "name": "Conqueror_g10_447dc3",
+          "rating": 1063,
+          "matches": 269,
+          "wins": 81,
+          "generation": 10
+        },
+        {
+          "name": "Conqueror_g10_c1e73e",
+          "rating": 1055,
+          "matches": 84,
+          "wins": 19,
+          "generation": 10
         }
       ]
     },
@@ -151,6 +277,20 @@
           "rating": 1068,
           "matches": 103,
           "wins": 25,
+          "generation": 11
+        },
+        {
+          "name": "Conqueror_g11_755fa9",
+          "rating": 1051,
+          "matches": 1032,
+          "wins": 205,
+          "generation": 11
+        },
+        {
+          "name": "Conqueror_g11_6c48eb",
+          "rating": 1050,
+          "matches": 280,
+          "wins": 85,
           "generation": 11
         }
       ]
@@ -176,6 +316,20 @@
           "matches": 736,
           "wins": 204,
           "generation": 13
+        },
+        {
+          "name": "Conqueror_g13_8fa0f9",
+          "rating": 1040,
+          "matches": 77,
+          "wins": 15,
+          "generation": 13
+        },
+        {
+          "name": "Conqueror_g13_036b6a",
+          "rating": 1032,
+          "matches": 68,
+          "wins": 12,
+          "generation": 13
         }
       ]
     },
@@ -187,6 +341,20 @@
           "rating": 1205,
           "matches": 351,
           "wins": 131,
+          "generation": 14
+        },
+        {
+          "name": "Conqueror_g14_5ae6c0",
+          "rating": 1168,
+          "matches": 156,
+          "wins": 48,
+          "generation": 14
+        },
+        {
+          "name": "Conqueror_g14_2486d3",
+          "rating": 1141,
+          "matches": 244,
+          "wins": 72,
           "generation": 14
         }
       ]
@@ -200,6 +368,20 @@
           "matches": 51,
           "wins": 17,
           "generation": 15
+        },
+        {
+          "name": "Conqueror_g15_313179",
+          "rating": 1170,
+          "matches": 107,
+          "wins": 32,
+          "generation": 15
+        },
+        {
+          "name": "Conqueror_g15_eb52b8",
+          "rating": 1145,
+          "matches": 144,
+          "wins": 41,
+          "generation": 15
         }
       ]
     },
@@ -211,6 +393,13 @@
           "rating": 1110,
           "matches": 466,
           "wins": 111,
+          "generation": 16
+        },
+        {
+          "name": "Conqueror_g16_3f3a3d",
+          "rating": 1063,
+          "matches": 89,
+          "wins": 18,
           "generation": 16
         }
       ]
@@ -224,6 +413,13 @@
           "matches": 310,
           "wins": 77,
           "generation": 17
+        },
+        {
+          "name": "Conqueror_g17_397562",
+          "rating": 1103,
+          "matches": 420,
+          "wins": 94,
+          "generation": 17
         }
       ]
     },
@@ -235,6 +431,13 @@
           "rating": 1132,
           "matches": 443,
           "wins": 119,
+          "generation": 18
+        },
+        {
+          "name": "Conqueror_g18_7e8c2e",
+          "rating": 1086,
+          "matches": 105,
+          "wins": 23,
           "generation": 18
         }
       ]
@@ -260,6 +463,20 @@
           "matches": 141,
           "wins": 42,
           "generation": 20
+        },
+        {
+          "name": "Conqueror_g20_19eb85",
+          "rating": 1122,
+          "matches": 160,
+          "wins": 41,
+          "generation": 20
+        },
+        {
+          "name": "Conqueror_g20_f5c991",
+          "rating": 1104,
+          "matches": 222,
+          "wins": 49,
+          "generation": 20
         }
       ]
     },
@@ -282,11 +499,11 @@
       "rank": 1,
       "name": "Conqueror_g20_43253a",
       "generation": 20,
-      "crossRating": 1043.02,
-      "crossWinRate": 0.341,
-      "crossPpg": 2.242,
-      "crossPlayed": 91,
-      "crossWins": 31,
+      "crossRating": 1040.45,
+      "crossWinRate": 0.321,
+      "crossPpg": 2.281,
+      "crossPlayed": 196,
+      "crossWins": 63,
       "globalRating": 1151,
       "globalMatches": 141,
       "globalWinRate": 0.298
@@ -295,454 +512,1105 @@
       "rank": 2,
       "name": "Conqueror_g21_e2aa5a",
       "generation": 21,
-      "crossRating": 1036.15,
-      "crossWinRate": 0.333,
-      "crossPpg": 2.229,
-      "crossPlayed": 96,
-      "crossWins": 32,
+      "crossRating": 1028.25,
+      "crossWinRate": 0.278,
+      "crossPpg": 2.19,
+      "crossPlayed": 216,
+      "crossWins": 60,
       "globalRating": 1095,
       "globalMatches": 73,
       "globalWinRate": 0.192
     },
     {
       "rank": 3,
-      "name": "Conqueror_g13_b41df9",
-      "generation": 13,
-      "crossRating": 1030.73,
-      "crossWinRate": 0.295,
-      "crossPpg": 2.284,
-      "crossPlayed": 95,
-      "crossWins": 28,
-      "globalRating": 1124,
-      "globalMatches": 736,
-      "globalWinRate": 0.277
-    },
-    {
-      "rank": 4,
-      "name": "Conqueror_g17_6d0fb0",
-      "generation": 17,
-      "crossRating": 1018.17,
-      "crossWinRate": 0.257,
-      "crossPpg": 1.901,
-      "crossPlayed": 101,
-      "crossWins": 26,
-      "globalRating": 1116,
-      "globalMatches": 310,
-      "globalWinRate": 0.248
-    },
-    {
-      "rank": 5,
-      "name": "Conqueror_g9_01de66",
-      "generation": 9,
-      "crossRating": 1011.82,
-      "crossWinRate": 0.23,
-      "crossPpg": 2.04,
-      "crossPlayed": 100,
-      "crossWins": 23,
-      "globalRating": 1093,
-      "globalMatches": 25,
-      "globalWinRate": 0.36
-    },
-    {
-      "rank": 6,
-      "name": "Conqueror_g4_be92c1",
-      "generation": 4,
-      "crossRating": 1011,
-      "crossWinRate": 0.206,
-      "crossPpg": 1.794,
-      "crossPlayed": 97,
-      "crossWins": 20,
-      "globalRating": 1079,
-      "globalMatches": 91,
-      "globalWinRate": 0.297
-    },
-    {
-      "rank": 7,
-      "name": "Conqueror_g14_8d5369",
-      "generation": 14,
-      "crossRating": 1009.26,
-      "crossWinRate": 0.255,
-      "crossPpg": 2.224,
-      "crossPlayed": 98,
-      "crossWins": 25,
-      "globalRating": 1205,
-      "globalMatches": 351,
-      "globalWinRate": 0.373
-    },
-    {
-      "rank": 8,
-      "name": "Conqueror_g3_be9a58",
-      "generation": 3,
-      "crossRating": 1009.17,
-      "crossWinRate": 0.207,
-      "crossPpg": 1.851,
-      "crossPlayed": 87,
-      "crossWins": 18,
-      "globalRating": 1026,
-      "globalMatches": 350,
-      "globalWinRate": 0.251
-    },
-    {
-      "rank": 9,
-      "name": "Conqueror_g15_2c15dc",
-      "generation": 15,
-      "crossRating": 1006.69,
-      "crossWinRate": 0.215,
-      "crossPpg": 2.19,
-      "crossPlayed": 79,
-      "crossWins": 17,
-      "globalRating": 1181,
-      "globalMatches": 51,
-      "globalWinRate": 0.333
-    },
-    {
-      "rank": 10,
-      "name": "Conqueror_g18_6a26b3",
-      "generation": 18,
-      "crossRating": 1004.88,
-      "crossWinRate": 0.225,
-      "crossPpg": 2.146,
-      "crossPlayed": 89,
-      "crossWins": 20,
-      "globalRating": 1132,
-      "globalMatches": 443,
-      "globalWinRate": 0.269
-    },
-    {
-      "rank": 11,
       "name": "Conqueror_g19_9533e3",
       "generation": 19,
-      "crossRating": 1000.91,
-      "crossWinRate": 0.241,
-      "crossPpg": 2.145,
-      "crossPlayed": 83,
-      "crossWins": 20,
+      "crossRating": 1027.94,
+      "crossWinRate": 0.291,
+      "crossPpg": 2.221,
+      "crossPlayed": 213,
+      "crossWins": 62,
       "globalRating": 1157,
       "globalMatches": 397,
       "globalWinRate": 0.307
     },
     {
-      "rank": 12,
-      "name": "Conqueror_g16_e79590",
-      "generation": 16,
-      "crossRating": 999.66,
-      "crossWinRate": 0.17,
-      "crossPpg": 1.67,
-      "crossPlayed": 88,
-      "crossWins": 15,
-      "globalRating": 1110,
-      "globalMatches": 466,
-      "globalWinRate": 0.238
+      "rank": 4,
+      "name": "Conqueror_g14_8d5369",
+      "generation": 14,
+      "crossRating": 1024.26,
+      "crossWinRate": 0.271,
+      "crossPpg": 2.31,
+      "crossPlayed": 210,
+      "crossWins": 57,
+      "globalRating": 1205,
+      "globalMatches": 351,
+      "globalWinRate": 0.373
     },
     {
-      "rank": 13,
-      "name": "Conqueror_g12_f23241",
-      "generation": 12,
-      "crossRating": 998.1,
-      "crossWinRate": 0.212,
-      "crossPpg": 2.061,
-      "crossPlayed": 99,
-      "crossWins": 21,
-      "globalRating": 1068,
-      "globalMatches": 787,
-      "globalWinRate": 0.22
+      "rank": 5,
+      "name": "Conqueror_g10_c1e73e",
+      "generation": 10,
+      "crossRating": 1023.03,
+      "crossWinRate": 0.264,
+      "crossPpg": 2.076,
+      "crossPlayed": 197,
+      "crossWins": 52,
+      "globalRating": 1055,
+      "globalMatches": 84,
+      "globalWinRate": 0.226
     },
     {
-      "rank": 14,
+      "rank": 6,
+      "name": "Conqueror_g9_aa6fcf",
+      "generation": 9,
+      "crossRating": 1021.86,
+      "crossWinRate": 0.257,
+      "crossPpg": 2.017,
+      "crossPlayed": 179,
+      "crossWins": 46,
+      "globalRating": 1051,
+      "globalMatches": 90,
+      "globalWinRate": 0.2
+    },
+    {
+      "rank": 7,
+      "name": "Conqueror_g17_397562",
+      "generation": 17,
+      "crossRating": 1021.24,
+      "crossWinRate": 0.255,
+      "crossPpg": 2.071,
+      "crossPlayed": 184,
+      "crossWins": 47,
+      "globalRating": 1103,
+      "globalMatches": 420,
+      "globalWinRate": 0.224
+    },
+    {
+      "rank": 8,
+      "name": "Conqueror_g15_eb52b8",
+      "generation": 15,
+      "crossRating": 1021.01,
+      "crossWinRate": 0.257,
+      "crossPpg": 2.134,
+      "crossPlayed": 187,
+      "crossWins": 48,
+      "globalRating": 1145,
+      "globalMatches": 144,
+      "globalWinRate": 0.285
+    },
+    {
+      "rank": 9,
+      "name": "Conqueror_g20_f5c991",
+      "generation": 20,
+      "crossRating": 1019.94,
+      "crossWinRate": 0.272,
+      "crossPpg": 2.084,
+      "crossPlayed": 191,
+      "crossWins": 52,
+      "globalRating": 1104,
+      "globalMatches": 222,
+      "globalWinRate": 0.221
+    },
+    {
+      "rank": 10,
+      "name": "Conqueror_g15_2c15dc",
+      "generation": 15,
+      "crossRating": 1019.83,
+      "crossWinRate": 0.259,
+      "crossPpg": 2.151,
+      "crossPlayed": 185,
+      "crossWins": 48,
+      "globalRating": 1181,
+      "globalMatches": 51,
+      "globalWinRate": 0.333
+    },
+    {
+      "rank": 11,
       "name": "Conqueror_g6_9eb2e4",
       "generation": 6,
-      "crossRating": 996.16,
-      "crossWinRate": 0.153,
-      "crossPpg": 1.824,
-      "crossPlayed": 85,
-      "crossWins": 13,
+      "crossRating": 1019.74,
+      "crossWinRate": 0.25,
+      "crossPpg": 1.865,
+      "crossPlayed": 208,
+      "crossWins": 52,
       "globalRating": 1063,
       "globalMatches": 566,
       "globalWinRate": 0.309
     },
     {
-      "rank": 15,
-      "name": "Conqueror_g10_34ca94",
-      "generation": 10,
-      "crossRating": 994.33,
-      "crossWinRate": 0.207,
-      "crossPpg": 1.724,
-      "crossPlayed": 87,
-      "crossWins": 18,
-      "globalRating": 1072,
-      "globalMatches": 278,
-      "globalWinRate": 0.234
+      "rank": 12,
+      "name": "Conqueror_g14_5ae6c0",
+      "generation": 14,
+      "crossRating": 1018.3,
+      "crossWinRate": 0.28,
+      "crossPpg": 2.28,
+      "crossPlayed": 189,
+      "crossWins": 53,
+      "globalRating": 1168,
+      "globalMatches": 156,
+      "globalWinRate": 0.308
     },
     {
-      "rank": 16,
-      "name": "Conqueror_g11_224717",
-      "generation": 11,
-      "crossRating": 992.42,
-      "crossWinRate": 0.185,
-      "crossPpg": 1.924,
-      "crossPlayed": 92,
-      "crossWins": 17,
-      "globalRating": 1068,
-      "globalMatches": 103,
-      "globalWinRate": 0.243
-    },
-    {
-      "rank": 17,
-      "name": "Conqueror_g8_82d39b",
-      "generation": 8,
-      "crossRating": 990.83,
-      "crossWinRate": 0.17,
-      "crossPpg": 1.849,
-      "crossPlayed": 106,
-      "crossWins": 18,
-      "globalRating": 1132,
-      "globalMatches": 45,
-      "globalWinRate": 0.422
-    },
-    {
-      "rank": 18,
-      "name": "Conqueror_g5_3087ea",
-      "generation": 5,
-      "crossRating": 987.38,
-      "crossWinRate": 0.159,
-      "crossPpg": 1.72,
-      "crossPlayed": 82,
-      "crossWins": 13,
-      "globalRating": 1066,
-      "globalMatches": 93,
-      "globalWinRate": 0.237
-    },
-    {
-      "rank": 19,
-      "name": "Conqueror_g7_3b651e",
-      "generation": 7,
-      "crossRating": 987.03,
-      "crossWinRate": 0.14,
-      "crossPpg": 1.709,
-      "crossPlayed": 86,
-      "crossWins": 12,
-      "globalRating": 1056,
-      "globalMatches": 499,
-      "globalWinRate": 0.325
-    },
-    {
-      "rank": 20,
+      "rank": 13,
       "name": "Conqueror_g2_6b59e8",
       "generation": 2,
-      "crossRating": 984.38,
-      "crossWinRate": 0.143,
-      "crossPpg": 1.67,
-      "crossPlayed": 91,
-      "crossWins": 13,
+      "crossRating": 1017.14,
+      "crossWinRate": 0.25,
+      "crossPpg": 2.026,
+      "crossPlayed": 192,
+      "crossWins": 48,
       "globalRating": 990,
       "globalMatches": 351,
       "globalWinRate": 0.177
     },
     {
+      "rank": 14,
+      "name": "Conqueror_g17_6d0fb0",
+      "generation": 17,
+      "crossRating": 1016.15,
+      "crossWinRate": 0.228,
+      "crossPpg": 2.01,
+      "crossPlayed": 206,
+      "crossWins": 47,
+      "globalRating": 1116,
+      "globalMatches": 310,
+      "globalWinRate": 0.248
+    },
+    {
+      "rank": 15,
+      "name": "Conqueror_g16_e79590",
+      "generation": 16,
+      "crossRating": 1015.32,
+      "crossWinRate": 0.241,
+      "crossPpg": 2.052,
+      "crossPlayed": 174,
+      "crossWins": 42,
+      "globalRating": 1110,
+      "globalMatches": 466,
+      "globalWinRate": 0.238
+    },
+    {
+      "rank": 16,
+      "name": "Conqueror_g8_579783",
+      "generation": 8,
+      "crossRating": 1015.11,
+      "crossWinRate": 0.238,
+      "crossPpg": 1.852,
+      "crossPlayed": 189,
+      "crossWins": 45,
+      "globalRating": 1085,
+      "globalMatches": 251,
+      "globalWinRate": 0.327
+    },
+    {
+      "rank": 17,
+      "name": "Conqueror_g13_8fa0f9",
+      "generation": 13,
+      "crossRating": 1010.32,
+      "crossWinRate": 0.232,
+      "crossPpg": 1.945,
+      "crossPlayed": 181,
+      "crossWins": 42,
+      "globalRating": 1040,
+      "globalMatches": 77,
+      "globalWinRate": 0.195
+    },
+    {
+      "rank": 18,
+      "name": "Conqueror_g16_3f3a3d",
+      "generation": 16,
+      "crossRating": 1009.3,
+      "crossWinRate": 0.24,
+      "crossPpg": 1.911,
+      "crossPlayed": 192,
+      "crossWins": 46,
+      "globalRating": 1063,
+      "globalMatches": 89,
+      "globalWinRate": 0.202
+    },
+    {
+      "rank": 19,
+      "name": "Conqueror_g20_19eb85",
+      "generation": 20,
+      "crossRating": 1007.87,
+      "crossWinRate": 0.238,
+      "crossPpg": 2.162,
+      "crossPlayed": 185,
+      "crossWins": 44,
+      "globalRating": 1122,
+      "globalMatches": 160,
+      "globalWinRate": 0.256
+    },
+    {
+      "rank": 20,
+      "name": "Conqueror_g14_2486d3",
+      "generation": 14,
+      "crossRating": 1006.35,
+      "crossWinRate": 0.215,
+      "crossPpg": 1.915,
+      "crossPlayed": 177,
+      "crossWins": 38,
+      "globalRating": 1141,
+      "globalMatches": 244,
+      "globalWinRate": 0.295
+    },
+    {
       "rank": 21,
-      "name": "Tactician",
-      "generation": 0,
-      "crossRating": 949.05,
-      "crossWinRate": 0,
-      "crossPpg": 1.875,
-      "crossPlayed": 88,
-      "crossWins": 0,
-      "globalRating": 875,
-      "globalMatches": 887,
-      "globalWinRate": 0
+      "name": "Conqueror_g8_5c68e4",
+      "generation": 8,
+      "crossRating": 1006.23,
+      "crossWinRate": 0.211,
+      "crossPpg": 1.873,
+      "crossPlayed": 204,
+      "crossWins": 43,
+      "globalRating": 1097,
+      "globalMatches": 167,
+      "globalWinRate": 0.335
     },
     {
       "rank": 22,
-      "name": "Phalanx_g1_5b920f",
-      "generation": 1,
-      "crossRating": 938.87,
+      "name": "Conqueror_g18_7e8c2e",
+      "generation": 18,
+      "crossRating": 1005.55,
+      "crossWinRate": 0.229,
+      "crossPpg": 2.03,
+      "crossPlayed": 201,
+      "crossWins": 46,
+      "globalRating": 1086,
+      "globalMatches": 105,
+      "globalWinRate": 0.219
+    },
+    {
+      "rank": 23,
+      "name": "Conqueror_g9_01de66",
+      "generation": 9,
+      "crossRating": 1005.36,
+      "crossWinRate": 0.212,
+      "crossPpg": 1.788,
+      "crossPlayed": 170,
+      "crossWins": 36,
+      "globalRating": 1093,
+      "globalMatches": 25,
+      "globalWinRate": 0.36
+    },
+    {
+      "rank": 24,
+      "name": "Conqueror_g18_6a26b3",
+      "generation": 18,
+      "crossRating": 1004.1,
+      "crossWinRate": 0.2,
+      "crossPpg": 2.018,
+      "crossPlayed": 165,
+      "crossWins": 33,
+      "globalRating": 1132,
+      "globalMatches": 443,
+      "globalWinRate": 0.269
+    },
+    {
+      "rank": 25,
+      "name": "Conqueror_g9_469924",
+      "generation": 9,
+      "crossRating": 1003.87,
+      "crossWinRate": 0.215,
+      "crossPpg": 1.994,
+      "crossPlayed": 177,
+      "crossWins": 38,
+      "globalRating": 1062,
+      "globalMatches": 109,
+      "globalWinRate": 0.275
+    },
+    {
+      "rank": 26,
+      "name": "Conqueror_g5_edeed5",
+      "generation": 5,
+      "crossRating": 1003.59,
+      "crossWinRate": 0.203,
+      "crossPpg": 1.976,
+      "crossPlayed": 207,
+      "crossWins": 42,
+      "globalRating": 1049,
+      "globalMatches": 789,
+      "globalWinRate": 0.166
+    },
+    {
+      "rank": 27,
+      "name": "Conqueror_g15_313179",
+      "generation": 15,
+      "crossRating": 1003.24,
+      "crossWinRate": 0.228,
+      "crossPpg": 2.114,
+      "crossPlayed": 184,
+      "crossWins": 42,
+      "globalRating": 1170,
+      "globalMatches": 107,
+      "globalWinRate": 0.299
+    },
+    {
+      "rank": 28,
+      "name": "Conqueror_g4_3fd4ce",
+      "generation": 4,
+      "crossRating": 1002.06,
+      "crossWinRate": 0.202,
+      "crossPpg": 1.852,
+      "crossPlayed": 183,
+      "crossWins": 37,
+      "globalRating": 1057,
+      "globalMatches": 476,
+      "globalWinRate": 0.313
+    },
+    {
+      "rank": 29,
+      "name": "Conqueror_g12_f23241",
+      "generation": 12,
+      "crossRating": 1001.95,
+      "crossWinRate": 0.18,
+      "crossPpg": 1.938,
+      "crossPlayed": 194,
+      "crossWins": 35,
+      "globalRating": 1068,
+      "globalMatches": 787,
+      "globalWinRate": 0.22
+    },
+    {
+      "rank": 30,
+      "name": "Conqueror_g11_224717",
+      "generation": 11,
+      "crossRating": 1001.73,
+      "crossWinRate": 0.196,
+      "crossPpg": 1.871,
+      "crossPlayed": 194,
+      "crossWins": 38,
+      "globalRating": 1068,
+      "globalMatches": 103,
+      "globalWinRate": 0.243
+    },
+    {
+      "rank": 31,
+      "name": "Conqueror_g13_036b6a",
+      "generation": 13,
+      "crossRating": 1001.37,
+      "crossWinRate": 0.203,
+      "crossPpg": 1.92,
+      "crossPlayed": 187,
+      "crossWins": 38,
+      "globalRating": 1032,
+      "globalMatches": 68,
+      "globalWinRate": 0.176
+    },
+    {
+      "rank": 32,
+      "name": "Conqueror_g7_efa4e0",
+      "generation": 7,
+      "crossRating": 1000.77,
+      "crossWinRate": 0.209,
+      "crossPpg": 1.895,
+      "crossPlayed": 172,
+      "crossWins": 36,
+      "globalRating": 1052,
+      "globalMatches": 1551,
+      "globalWinRate": 0.228
+    },
+    {
+      "rank": 33,
+      "name": "Conqueror_g4_de5d02",
+      "generation": 4,
+      "crossRating": 998.74,
+      "crossWinRate": 0.19,
+      "crossPpg": 1.722,
+      "crossPlayed": 205,
+      "crossWins": 39,
+      "globalRating": 1032,
+      "globalMatches": 738,
+      "globalWinRate": 0.19
+    },
+    {
+      "rank": 34,
+      "name": "Conqueror_g4_be92c1",
+      "generation": 4,
+      "crossRating": 996.54,
+      "crossWinRate": 0.185,
+      "crossPpg": 1.951,
+      "crossPlayed": 184,
+      "crossWins": 34,
+      "globalRating": 1079,
+      "globalMatches": 91,
+      "globalWinRate": 0.297
+    },
+    {
+      "rank": 35,
+      "name": "Conqueror_g10_447dc3",
+      "generation": 10,
+      "crossRating": 995.4,
+      "crossWinRate": 0.196,
+      "crossPpg": 1.799,
+      "crossPlayed": 184,
+      "crossWins": 36,
+      "globalRating": 1063,
+      "globalMatches": 269,
+      "globalWinRate": 0.301
+    },
+    {
+      "rank": 36,
+      "name": "Conqueror_g2_e0f65e",
+      "generation": 2,
+      "crossRating": 995.18,
+      "crossWinRate": 0.192,
+      "crossPpg": 1.86,
+      "crossPlayed": 172,
+      "crossWins": 33,
+      "globalRating": 982,
+      "globalMatches": 43,
+      "globalWinRate": 0.209
+    },
+    {
+      "rank": 37,
+      "name": "Conqueror_g6_27c4e7",
+      "generation": 6,
+      "crossRating": 995.12,
+      "crossWinRate": 0.198,
+      "crossPpg": 1.846,
+      "crossPlayed": 182,
+      "crossWins": 36,
+      "globalRating": 1055,
+      "globalMatches": 1026,
+      "globalWinRate": 0.188
+    },
+    {
+      "rank": 38,
+      "name": "Conqueror_g2_e90f66",
+      "generation": 2,
+      "crossRating": 994.92,
+      "crossWinRate": 0.176,
+      "crossPpg": 1.78,
+      "crossPlayed": 205,
+      "crossWins": 36,
+      "globalRating": 975,
+      "globalMatches": 488,
+      "globalWinRate": 0.189
+    },
+    {
+      "rank": 39,
+      "name": "Conqueror_g13_b41df9",
+      "generation": 13,
+      "crossRating": 994.89,
+      "crossWinRate": 0.174,
+      "crossPpg": 1.878,
+      "crossPlayed": 172,
+      "crossWins": 30,
+      "globalRating": 1124,
+      "globalMatches": 736,
+      "globalWinRate": 0.277
+    },
+    {
+      "rank": 40,
+      "name": "Conqueror_g6_53407c",
+      "generation": 6,
+      "crossRating": 992.83,
+      "crossWinRate": 0.174,
+      "crossPpg": 1.764,
+      "crossPlayed": 195,
+      "crossWins": 34,
+      "globalRating": 1045,
+      "globalMatches": 921,
+      "globalWinRate": 0.161
+    },
+    {
+      "rank": 41,
+      "name": "Conqueror_g7_31769b",
+      "generation": 7,
+      "crossRating": 988.82,
+      "crossWinRate": 0.172,
+      "crossPpg": 1.813,
+      "crossPlayed": 192,
+      "crossWins": 33,
+      "globalRating": 1043,
+      "globalMatches": 282,
+      "globalWinRate": 0.309
+    },
+    {
+      "rank": 42,
+      "name": "Conqueror_g11_6c48eb",
+      "generation": 11,
+      "crossRating": 986.12,
+      "crossWinRate": 0.165,
+      "crossPpg": 1.797,
+      "crossPlayed": 182,
+      "crossWins": 30,
+      "globalRating": 1050,
+      "globalMatches": 280,
+      "globalWinRate": 0.304
+    },
+    {
+      "rank": 43,
+      "name": "Conqueror_g3_be9a58",
+      "generation": 3,
+      "crossRating": 986,
+      "crossWinRate": 0.169,
+      "crossPpg": 1.842,
+      "crossPlayed": 177,
+      "crossWins": 30,
+      "globalRating": 1026,
+      "globalMatches": 350,
+      "globalWinRate": 0.251
+    },
+    {
+      "rank": 44,
+      "name": "Conqueror_g5_3087ea",
+      "generation": 5,
+      "crossRating": 985.75,
+      "crossWinRate": 0.155,
+      "crossPpg": 1.818,
+      "crossPlayed": 187,
+      "crossWins": 29,
+      "globalRating": 1066,
+      "globalMatches": 93,
+      "globalWinRate": 0.237
+    },
+    {
+      "rank": 45,
+      "name": "Conqueror_g7_3b651e",
+      "generation": 7,
+      "crossRating": 985.2,
+      "crossWinRate": 0.158,
+      "crossPpg": 1.758,
+      "crossPlayed": 190,
+      "crossWins": 30,
+      "globalRating": 1056,
+      "globalMatches": 499,
+      "globalWinRate": 0.325
+    },
+    {
+      "rank": 46,
+      "name": "Conqueror_g8_82d39b",
+      "generation": 8,
+      "crossRating": 984.75,
+      "crossWinRate": 0.168,
+      "crossPpg": 1.684,
+      "crossPlayed": 190,
+      "crossWins": 32,
+      "globalRating": 1132,
+      "globalMatches": 45,
+      "globalWinRate": 0.422
+    },
+    {
+      "rank": 47,
+      "name": "Conqueror_g11_755fa9",
+      "generation": 11,
+      "crossRating": 984.39,
+      "crossWinRate": 0.161,
+      "crossPpg": 1.785,
+      "crossPlayed": 186,
+      "crossWins": 30,
+      "globalRating": 1051,
+      "globalMatches": 1032,
+      "globalWinRate": 0.199
+    },
+    {
+      "rank": 48,
+      "name": "Conqueror_g5_f15d3e",
+      "generation": 5,
+      "crossRating": 978.15,
+      "crossWinRate": 0.145,
+      "crossPpg": 1.737,
+      "crossPlayed": 186,
+      "crossWins": 27,
+      "globalRating": 1060,
+      "globalMatches": 1107,
+      "globalWinRate": 0.198
+    },
+    {
+      "rank": 49,
+      "name": "Conqueror_g10_34ca94",
+      "generation": 10,
+      "crossRating": 972.23,
+      "crossWinRate": 0.131,
+      "crossPpg": 1.623,
+      "crossPlayed": 183,
+      "crossWins": 24,
+      "globalRating": 1072,
+      "globalMatches": 278,
+      "globalWinRate": 0.234
+    },
+    {
+      "rank": 50,
+      "name": "Cluster_08",
+      "generation": 0,
+      "crossRating": 942.95,
       "crossWinRate": 0,
       "crossPpg": 3,
-      "crossPlayed": 80,
+      "crossPlayed": 181,
+      "crossWins": 0,
+      "globalRating": 844,
+      "globalMatches": 192,
+      "globalWinRate": 0
+    },
+    {
+      "rank": 51,
+      "name": "Phalanx_g1_5b920f",
+      "generation": 1,
+      "crossRating": 942.31,
+      "crossWinRate": 0,
+      "crossPpg": 2.946,
+      "crossPlayed": 186,
       "crossWins": 0,
       "globalRating": 819,
       "globalMatches": 55,
       "globalWinRate": 0
+    },
+    {
+      "rank": 52,
+      "name": "Pinwheel",
+      "generation": 0,
+      "crossRating": 939.39,
+      "crossWinRate": 0,
+      "crossPpg": 2.829,
+      "crossPlayed": 181,
+      "crossWins": 0,
+      "globalRating": 848,
+      "globalMatches": 463,
+      "globalWinRate": 0.002
+    },
+    {
+      "rank": 53,
+      "name": "Tactician",
+      "generation": 0,
+      "crossRating": 937.08,
+      "crossWinRate": 0,
+      "crossPpg": 1.921,
+      "crossPlayed": 191,
+      "crossWins": 0,
+      "globalRating": 875,
+      "globalMatches": 887,
+      "globalWinRate": 0
     }
   ],
   "correlations": {
-    "rhoXrXw": 0.9175607001693958,
-    "rhoXrG": 0.6487859966120836
+    "rhoXrXw": 0.9800032252862442,
+    "rhoXrG": 0.5853894533139816
   },
   "pin": {
     "name": "Conqueror_g14_8d5369",
     "rows": [
       {
         "name": "Tactician",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
+        "encounters": 12,
+        "wins": 9,
+        "winRate": 0.75,
         "generation": 0,
         "globalRating": 875
       },
       {
+        "name": "Pinwheel",
+        "encounters": 18,
+        "wins": 6,
+        "winRate": 0.333,
+        "generation": 0,
+        "globalRating": 848
+      },
+      {
+        "name": "Cluster_08",
+        "encounters": 17,
+        "wins": 7,
+        "winRate": 0.412,
+        "generation": 0,
+        "globalRating": 844
+      },
+      {
         "name": "Phalanx_g1_5b920f",
-        "encounters": 16,
-        "wins": 4,
-        "winRate": 0.25,
+        "encounters": 14,
+        "wins": 7,
+        "winRate": 0.5,
         "generation": 1,
         "globalRating": 819
       },
       {
         "name": "Conqueror_g2_6b59e8",
-        "encounters": 21,
-        "wins": 11,
-        "winRate": 0.524,
+        "encounters": 22,
+        "wins": 14,
+        "winRate": 0.636,
         "generation": 2,
         "globalRating": 990
       },
       {
+        "name": "Conqueror_g2_e0f65e",
+        "encounters": 11,
+        "wins": 7,
+        "winRate": 0.636,
+        "generation": 2,
+        "globalRating": 982
+      },
+      {
+        "name": "Conqueror_g2_e90f66",
+        "encounters": 17,
+        "wins": 12,
+        "winRate": 0.706,
+        "generation": 2,
+        "globalRating": 975
+      },
+      {
         "name": "Conqueror_g3_be9a58",
-        "encounters": 19,
-        "wins": 11,
-        "winRate": 0.579,
+        "encounters": 21,
+        "wins": 14,
+        "winRate": 0.667,
         "generation": 3,
         "globalRating": 1026
       },
       {
         "name": "Conqueror_g4_be92c1",
-        "encounters": 19,
-        "wins": 11,
-        "winRate": 0.579,
+        "encounters": 14,
+        "wins": 7,
+        "winRate": 0.5,
         "generation": 4,
         "globalRating": 1079
       },
       {
-        "name": "Conqueror_g5_3087ea",
+        "name": "Conqueror_g4_3fd4ce",
         "encounters": 18,
-        "wins": 8,
-        "winRate": 0.444,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 4,
+        "globalRating": 1057
+      },
+      {
+        "name": "Conqueror_g4_de5d02",
+        "encounters": 22,
+        "wins": 11,
+        "winRate": 0.5,
+        "generation": 4,
+        "globalRating": 1032
+      },
+      {
+        "name": "Conqueror_g5_3087ea",
+        "encounters": 16,
+        "wins": 7,
+        "winRate": 0.438,
         "generation": 5,
         "globalRating": 1066
       },
       {
+        "name": "Conqueror_g5_f15d3e",
+        "encounters": 15,
+        "wins": 10,
+        "winRate": 0.667,
+        "generation": 5,
+        "globalRating": 1060
+      },
+      {
+        "name": "Conqueror_g5_edeed5",
+        "encounters": 19,
+        "wins": 13,
+        "winRate": 0.684,
+        "generation": 5,
+        "globalRating": 1049
+      },
+      {
         "name": "Conqueror_g6_9eb2e4",
-        "encounters": 18,
-        "wins": 11,
-        "winRate": 0.611,
+        "encounters": 12,
+        "wins": 8,
+        "winRate": 0.667,
         "generation": 6,
         "globalRating": 1063
       },
       {
+        "name": "Conqueror_g6_27c4e7",
+        "encounters": 9,
+        "wins": 8,
+        "winRate": 0.889,
+        "generation": 6,
+        "globalRating": 1055
+      },
+      {
+        "name": "Conqueror_g6_53407c",
+        "encounters": 18,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 6,
+        "globalRating": 1045
+      },
+      {
         "name": "Conqueror_g7_3b651e",
-        "encounters": 19,
-        "wins": 15,
-        "winRate": 0.789,
+        "encounters": 15,
+        "wins": 9,
+        "winRate": 0.6,
         "generation": 7,
         "globalRating": 1056
       },
       {
-        "name": "Conqueror_g8_82d39b",
-        "encounters": 16,
+        "name": "Conqueror_g7_efa4e0",
+        "encounters": 18,
         "wins": 9,
-        "winRate": 0.563,
+        "winRate": 0.5,
+        "generation": 7,
+        "globalRating": 1052
+      },
+      {
+        "name": "Conqueror_g7_31769b",
+        "encounters": 13,
+        "wins": 6,
+        "winRate": 0.462,
+        "generation": 7,
+        "globalRating": 1043
+      },
+      {
+        "name": "Conqueror_g8_82d39b",
+        "encounters": 18,
+        "wins": 13,
+        "winRate": 0.722,
         "generation": 8,
         "globalRating": 1132
       },
       {
+        "name": "Conqueror_g8_5c68e4",
+        "encounters": 18,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 8,
+        "globalRating": 1097
+      },
+      {
+        "name": "Conqueror_g8_579783",
+        "encounters": 10,
+        "wins": 6,
+        "winRate": 0.6,
+        "generation": 8,
+        "globalRating": 1085
+      },
+      {
         "name": "Conqueror_g9_01de66",
-        "encounters": 22,
-        "wins": 17,
-        "winRate": 0.773,
+        "encounters": 18,
+        "wins": 14,
+        "winRate": 0.778,
         "generation": 9,
         "globalRating": 1093
       },
       {
+        "name": "Conqueror_g9_469924",
+        "encounters": 16,
+        "wins": 13,
+        "winRate": 0.813,
+        "generation": 9,
+        "globalRating": 1062
+      },
+      {
+        "name": "Conqueror_g9_aa6fcf",
+        "encounters": 14,
+        "wins": 6,
+        "winRate": 0.429,
+        "generation": 9,
+        "globalRating": 1051
+      },
+      {
         "name": "Conqueror_g10_34ca94",
-        "encounters": 20,
-        "wins": 12,
-        "winRate": 0.6,
+        "encounters": 12,
+        "wins": 9,
+        "winRate": 0.75,
         "generation": 10,
         "globalRating": 1072
       },
       {
-        "name": "Conqueror_g11_224717",
-        "encounters": 18,
+        "name": "Conqueror_g10_447dc3",
+        "encounters": 13,
         "wins": 8,
-        "winRate": 0.444,
+        "winRate": 0.615,
+        "generation": 10,
+        "globalRating": 1063
+      },
+      {
+        "name": "Conqueror_g10_c1e73e",
+        "encounters": 22,
+        "wins": 12,
+        "winRate": 0.545,
+        "generation": 10,
+        "globalRating": 1055
+      },
+      {
+        "name": "Conqueror_g11_224717",
+        "encounters": 17,
+        "wins": 7,
+        "winRate": 0.412,
         "generation": 11,
         "globalRating": 1068
       },
       {
+        "name": "Conqueror_g11_755fa9",
+        "encounters": 10,
+        "wins": 4,
+        "winRate": 0.4,
+        "generation": 11,
+        "globalRating": 1051
+      },
+      {
+        "name": "Conqueror_g11_6c48eb",
+        "encounters": 13,
+        "wins": 6,
+        "winRate": 0.462,
+        "generation": 11,
+        "globalRating": 1050
+      },
+      {
         "name": "Conqueror_g12_f23241",
-        "encounters": 24,
-        "wins": 17,
-        "winRate": 0.708,
+        "encounters": 20,
+        "wins": 13,
+        "winRate": 0.65,
         "generation": 12,
         "globalRating": 1068
       },
       {
         "name": "Conqueror_g13_b41df9",
-        "encounters": 20,
-        "wins": 9,
-        "winRate": 0.45,
+        "encounters": 15,
+        "wins": 8,
+        "winRate": 0.533,
         "generation": 13,
         "globalRating": 1124
       },
       {
-        "name": "Conqueror_g15_2c15dc",
+        "name": "Conqueror_g13_8fa0f9",
+        "encounters": 12,
+        "wins": 7,
+        "winRate": 0.583,
+        "generation": 13,
+        "globalRating": 1040
+      },
+      {
+        "name": "Conqueror_g13_036b6a",
+        "encounters": 16,
+        "wins": 12,
+        "winRate": 0.75,
+        "generation": 13,
+        "globalRating": 1032
+      },
+      {
+        "name": "Conqueror_g14_5ae6c0",
+        "encounters": 18,
+        "wins": 13,
+        "winRate": 0.722,
+        "generation": 14,
+        "globalRating": 1168
+      },
+      {
+        "name": "Conqueror_g14_2486d3",
         "encounters": 13,
         "wins": 8,
         "winRate": 0.615,
+        "generation": 14,
+        "globalRating": 1141
+      },
+      {
+        "name": "Conqueror_g15_2c15dc",
+        "encounters": 18,
+        "wins": 8,
+        "winRate": 0.444,
         "generation": 15,
         "globalRating": 1181
       },
       {
+        "name": "Conqueror_g15_313179",
+        "encounters": 22,
+        "wins": 11,
+        "winRate": 0.5,
+        "generation": 15,
+        "globalRating": 1170
+      },
+      {
+        "name": "Conqueror_g15_eb52b8",
+        "encounters": 15,
+        "wins": 4,
+        "winRate": 0.267,
+        "generation": 15,
+        "globalRating": 1145
+      },
+      {
         "name": "Conqueror_g16_e79590",
-        "encounters": 23,
-        "wins": 13,
-        "winRate": 0.565,
+        "encounters": 17,
+        "wins": 10,
+        "winRate": 0.588,
         "generation": 16,
         "globalRating": 1110
       },
       {
+        "name": "Conqueror_g16_3f3a3d",
+        "encounters": 16,
+        "wins": 11,
+        "winRate": 0.688,
+        "generation": 16,
+        "globalRating": 1063
+      },
+      {
         "name": "Conqueror_g17_6d0fb0",
-        "encounters": 21,
-        "wins": 14,
-        "winRate": 0.667,
+        "encounters": 23,
+        "wins": 12,
+        "winRate": 0.522,
         "generation": 17,
         "globalRating": 1116
       },
       {
+        "name": "Conqueror_g17_397562",
+        "encounters": 13,
+        "wins": 5,
+        "winRate": 0.385,
+        "generation": 17,
+        "globalRating": 1103
+      },
+      {
         "name": "Conqueror_g18_6a26b3",
-        "encounters": 19,
-        "wins": 10,
-        "winRate": 0.526,
+        "encounters": 11,
+        "wins": 6,
+        "winRate": 0.545,
         "generation": 18,
         "globalRating": 1132
       },
       {
+        "name": "Conqueror_g18_7e8c2e",
+        "encounters": 19,
+        "wins": 13,
+        "winRate": 0.684,
+        "generation": 18,
+        "globalRating": 1086
+      },
+      {
         "name": "Conqueror_g19_9533e3",
-        "encounters": 14,
-        "wins": 4,
-        "winRate": 0.286,
+        "encounters": 20,
+        "wins": 10,
+        "winRate": 0.5,
         "generation": 19,
         "globalRating": 1157
       },
       {
         "name": "Conqueror_g20_43253a",
-        "encounters": 16,
-        "wins": 6,
-        "winRate": 0.375,
+        "encounters": 19,
+        "wins": 10,
+        "winRate": 0.526,
         "generation": 20,
         "globalRating": 1151
       },
       {
+        "name": "Conqueror_g20_19eb85",
+        "encounters": 15,
+        "wins": 7,
+        "winRate": 0.467,
+        "generation": 20,
+        "globalRating": 1122
+      },
+      {
+        "name": "Conqueror_g20_f5c991",
+        "encounters": 18,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 20,
+        "globalRating": 1104
+      },
+      {
         "name": "Conqueror_g21_e2aa5a",
         "encounters": 18,
-        "wins": 9,
-        "winRate": 0.5,
+        "wins": 11,
+        "winRate": 0.611,
         "generation": 21,
         "globalRating": 1095
       }
     ],
-    "totalEnc": 392,
-    "totalWin": 218,
-    "overallWinRate": 0.556
+    "totalEnc": 840,
+    "totalWin": 485,
+    "overallWinRate": 0.577
   }
 }

--- a/tournament/eras.json
+++ b/tournament/eras.json
@@ -1,248 +1,277 @@
 {
-  "generatedAt": "2026-05-08T03:57:45.843Z",
+  "generatedAt": "2026-05-08T06:36:40.758Z",
   "opts": {
-    "intervals": 10,
-    "top": 3,
-    "matches": 250,
+    "top": 1,
+    "matches": 400,
     "pool": null,
     "map": "lab1",
     "seed": 1,
-    "minPlayedInEra": 15,
-    "append": true
-  },
-  "logRange": {
-    "firstTs": "2026-05-07T22:52:53.185Z",
-    "lastTs": "2026-05-08T03:53:52.784Z",
-    "count": 4358
+    "minPlayed": 15,
+    "pin": "Conqueror_g14_8d5369",
+    "append": false
   },
   "eras": [
     {
-      "i": 1,
-      "endMatch": 435,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-07T23:06:31.573Z",
+      "generation": 0,
       "top": [
         {
-          "name": "Conqueror_g5_0b2647",
-          "rating": 1204,
-          "matches": 17
-        },
+          "name": "Tactician",
+          "rating": 875,
+          "matches": 887,
+          "wins": 0,
+          "generation": 0
+        }
+      ]
+    },
+    {
+      "generation": 1,
+      "top": [
+        {
+          "name": "Phalanx_g1_5b920f",
+          "rating": 819,
+          "matches": 55,
+          "wins": 0,
+          "generation": 1
+        }
+      ]
+    },
+    {
+      "generation": 2,
+      "top": [
         {
           "name": "Conqueror_g2_6b59e8",
-          "rating": 1192,
-          "matches": 16
-        },
-        {
-          "name": "Conqueror_g9_c81d7f",
-          "rating": 1179,
-          "matches": 15
+          "rating": 990,
+          "matches": 351,
+          "wins": 62,
+          "generation": 2
         }
       ]
     },
     {
-      "i": 2,
-      "endMatch": 871,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-07T23:15:46.865Z",
+      "generation": 3,
+      "top": [
+        {
+          "name": "Conqueror_g3_be9a58",
+          "rating": 1026,
+          "matches": 350,
+          "wins": 88,
+          "generation": 3
+        }
+      ]
+    },
+    {
+      "generation": 4,
+      "top": [
+        {
+          "name": "Conqueror_g4_be92c1",
+          "rating": 1079,
+          "matches": 91,
+          "wins": 27,
+          "generation": 4
+        }
+      ]
+    },
+    {
+      "generation": 5,
+      "top": [
+        {
+          "name": "Conqueror_g5_3087ea",
+          "rating": 1066,
+          "matches": 93,
+          "wins": 22,
+          "generation": 5
+        }
+      ]
+    },
+    {
+      "generation": 6,
       "top": [
         {
           "name": "Conqueror_g6_9eb2e4",
-          "rating": 1158,
-          "matches": 165
-        },
-        {
-          "name": "Conqueror_g9_c81d7f",
-          "rating": 1150,
-          "matches": 33
-        },
-        {
-          "name": "Conqueror_g10_447dc3",
-          "rating": 1147,
-          "matches": 33
+          "rating": 1063,
+          "matches": 566,
+          "wins": 175,
+          "generation": 6
         }
       ]
     },
     {
-      "i": 3,
-      "endMatch": 1307,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-07T23:20:16.869Z",
+      "generation": 7,
       "top": [
         {
-          "name": "Conqueror_g9_c81d7f",
-          "rating": 1177,
-          "matches": 40
-        },
-        {
-          "name": "Conqueror_g10_447dc3",
-          "rating": 1151,
-          "matches": 40
-        },
-        {
-          "name": "Conqueror_g6_9eb2e4",
-          "rating": 1147,
-          "matches": 243
+          "name": "Conqueror_g7_3b651e",
+          "rating": 1056,
+          "matches": 499,
+          "wins": 162,
+          "generation": 7
         }
       ]
     },
     {
-      "i": 4,
-      "endMatch": 1743,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T00:08:19.629Z",
+      "generation": 8,
       "top": [
         {
-          "name": "Conqueror_g8_74e11b",
-          "rating": 1178,
-          "matches": 73
-        },
-        {
-          "name": "Conqueror_g9_1e065b",
-          "rating": 1168,
-          "matches": 23
-        },
-        {
-          "name": "Conqueror_g6_9eb2e4",
-          "rating": 1134,
-          "matches": 302
+          "name": "Conqueror_g8_82d39b",
+          "rating": 1132,
+          "matches": 45,
+          "wins": 19,
+          "generation": 8
         }
       ]
     },
     {
-      "i": 5,
-      "endMatch": 2179,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T01:30:51.025Z",
+      "generation": 9,
       "top": [
         {
-          "name": "Conqueror_g8_4d842b",
-          "rating": 1277,
-          "matches": 22
-        },
-        {
-          "name": "Conqueror_g8_912a4c",
-          "rating": 1218,
-          "matches": 23
-        },
-        {
-          "name": "Conqueror_g11_755fa9",
-          "rating": 1208,
-          "matches": 23
+          "name": "Conqueror_g9_01de66",
+          "rating": 1093,
+          "matches": 25,
+          "wins": 9,
+          "generation": 9
         }
       ]
     },
     {
-      "i": 6,
-      "endMatch": 2614,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T01:39:07.334Z",
+      "generation": 10,
       "top": [
         {
-          "name": "Conqueror_g8_912a4c",
-          "rating": 1214,
-          "matches": 43
-        },
-        {
-          "name": "Conqueror_g8_4d842b",
-          "rating": 1207,
-          "matches": 43
-        },
-        {
-          "name": "Conqueror_g11_755fa9",
-          "rating": 1181,
-          "matches": 43
+          "name": "Conqueror_g10_34ca94",
+          "rating": 1072,
+          "matches": 278,
+          "wins": 65,
+          "generation": 10
         }
       ]
     },
     {
-      "i": 7,
-      "endMatch": 3050,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T02:16:25.189Z",
+      "generation": 11,
       "top": [
         {
-          "name": "Conqueror_g11_755fa9",
-          "rating": 1136,
-          "matches": 113
-        },
-        {
-          "name": "Conqueror_g8_4d842b",
-          "rating": 1129,
-          "matches": 111
-        },
-        {
-          "name": "Conqueror_g8_579783",
-          "rating": 1127,
-          "matches": 119
+          "name": "Conqueror_g11_224717",
+          "rating": 1068,
+          "matches": 103,
+          "wins": 25,
+          "generation": 11
         }
       ]
     },
     {
-      "i": 8,
-      "endMatch": 3486,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T03:07:15.620Z",
+      "generation": 12,
       "top": [
         {
-          "name": "Conqueror_g8_1c5660",
-          "rating": 1205,
-          "matches": 15
-        },
+          "name": "Conqueror_g12_f23241",
+          "rating": 1068,
+          "matches": 787,
+          "wins": 173,
+          "generation": 12
+        }
+      ]
+    },
+    {
+      "generation": 13,
+      "top": [
         {
-          "name": "Conqueror_g5_897d51",
-          "rating": 1147,
-          "matches": 43
-        },
-        {
-          "name": "Conqueror_g11_755fa9",
+          "name": "Conqueror_g13_b41df9",
           "rating": 1124,
-          "matches": 118
+          "matches": 736,
+          "wins": 204,
+          "generation": 13
         }
       ]
     },
     {
-      "i": 9,
-      "endMatch": 3922,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T03:31:37.865Z",
+      "generation": 14,
       "top": [
         {
-          "name": "Conqueror_g5_f15d3e",
-          "rating": 1208,
-          "matches": 40
-        },
-        {
-          "name": "Conqueror_g8_5c68e4",
-          "rating": 1183,
-          "matches": 32
-        },
-        {
-          "name": "Conqueror_g8_3280dd",
-          "rating": 1159,
-          "matches": 42
+          "name": "Conqueror_g14_8d5369",
+          "rating": 1205,
+          "matches": 351,
+          "wins": 131,
+          "generation": 14
         }
       ]
     },
     {
-      "i": 10,
-      "endMatch": 4358,
-      "startTs": "2026-05-07T22:52:53.185Z",
-      "endTs": "2026-05-08T03:53:52.784Z",
+      "generation": 15,
       "top": [
         {
-          "name": "Conqueror_g6_27c4e7",
-          "rating": 1206,
-          "matches": 27
-        },
+          "name": "Conqueror_g15_2c15dc",
+          "rating": 1181,
+          "matches": 51,
+          "wins": 17,
+          "generation": 15
+        }
+      ]
+    },
+    {
+      "generation": 16,
+      "top": [
         {
-          "name": "Conqueror_g8_bfcb0e",
-          "rating": 1189,
-          "matches": 56
-        },
+          "name": "Conqueror_g16_e79590",
+          "rating": 1110,
+          "matches": 466,
+          "wins": 111,
+          "generation": 16
+        }
+      ]
+    },
+    {
+      "generation": 17,
+      "top": [
         {
-          "name": "Conqueror_g5_f15d3e",
-          "rating": 1172,
-          "matches": 77
+          "name": "Conqueror_g17_6d0fb0",
+          "rating": 1116,
+          "matches": 310,
+          "wins": 77,
+          "generation": 17
+        }
+      ]
+    },
+    {
+      "generation": 18,
+      "top": [
+        {
+          "name": "Conqueror_g18_6a26b3",
+          "rating": 1132,
+          "matches": 443,
+          "wins": 119,
+          "generation": 18
+        }
+      ]
+    },
+    {
+      "generation": 19,
+      "top": [
+        {
+          "name": "Conqueror_g19_9533e3",
+          "rating": 1157,
+          "matches": 397,
+          "wins": 122,
+          "generation": 19
+        }
+      ]
+    },
+    {
+      "generation": 20,
+      "top": [
+        {
+          "name": "Conqueror_g20_43253a",
+          "rating": 1151,
+          "matches": 141,
+          "wins": 42,
+          "generation": 20
+        }
+      ]
+    },
+    {
+      "generation": 21,
+      "top": [
+        {
+          "name": "Conqueror_g21_e2aa5a",
+          "rating": 1095,
+          "matches": 73,
+          "wins": 14,
+          "generation": 21
         }
       ]
     }
@@ -250,568 +279,470 @@
   "missing": [],
   "standings": [
     {
-      "name": "Conqueror_g8_bfcb0e",
-      "author": "claude",
-      "played": 69,
-      "wins": 19,
-      "survived": 19,
-      "points": 166,
-      "totalRank": 179,
-      "totalTerritory": 12533,
-      "totalEliminationTick": 23675,
-      "eliminationCount": 50,
-      "avgRank": 2.5942028985507246,
-      "avgTerritory": 181.63768115942028,
-      "avgEliminationTick": 473.5,
-      "winRate": 0.2753623188405797,
-      "survivalRate": 0.2753623188405797,
-      "pointsPerGame": 2.4057971014492754,
-      "rating": 1038.24,
-      "rd": 41.83,
-      "firstEra": 10,
-      "appearances": [
-        {
-          "era": 10,
-          "rating": 1189,
-          "matches": 56
-        }
-      ]
+      "rank": 1,
+      "name": "Conqueror_g20_43253a",
+      "generation": 20,
+      "crossRating": 1043.02,
+      "crossWinRate": 0.341,
+      "crossPpg": 2.242,
+      "crossPlayed": 91,
+      "crossWins": 31,
+      "globalRating": 1151,
+      "globalMatches": 141,
+      "globalWinRate": 0.298
     },
     {
-      "name": "Conqueror_g8_579783",
-      "author": "claude",
-      "played": 80,
-      "wins": 24,
-      "survived": 24,
-      "points": 208,
-      "totalRank": 192,
-      "totalTerritory": 15830,
-      "totalEliminationTick": 26491,
-      "eliminationCount": 56,
-      "avgRank": 2.4,
-      "avgTerritory": 197.875,
-      "avgEliminationTick": 473.05357142857144,
-      "winRate": 0.3,
-      "survivalRate": 0.3,
-      "pointsPerGame": 2.6,
-      "rating": 1027.34,
-      "rd": 38.89,
-      "firstEra": 7,
-      "appearances": [
-        {
-          "era": 7,
-          "rating": 1127,
-          "matches": 119
-        }
-      ]
+      "rank": 2,
+      "name": "Conqueror_g21_e2aa5a",
+      "generation": 21,
+      "crossRating": 1036.15,
+      "crossWinRate": 0.333,
+      "crossPpg": 2.229,
+      "crossPlayed": 96,
+      "crossWins": 32,
+      "globalRating": 1095,
+      "globalMatches": 73,
+      "globalWinRate": 0.192
     },
     {
-      "name": "Conqueror_g8_3280dd",
-      "author": "claude",
-      "played": 69,
-      "wins": 19,
-      "survived": 19,
-      "points": 156,
-      "totalRank": 189,
-      "totalTerritory": 12530,
-      "totalEliminationTick": 22084,
-      "eliminationCount": 50,
-      "avgRank": 2.739130434782609,
-      "avgTerritory": 181.59420289855072,
-      "avgEliminationTick": 441.68,
-      "winRate": 0.2753623188405797,
-      "survivalRate": 0.2753623188405797,
-      "pointsPerGame": 2.260869565217391,
-      "rating": 1027.08,
-      "rd": 41.83,
-      "firstEra": 9,
-      "appearances": [
-        {
-          "era": 9,
-          "rating": 1159,
-          "matches": 42
-        }
-      ]
+      "rank": 3,
+      "name": "Conqueror_g13_b41df9",
+      "generation": 13,
+      "crossRating": 1030.73,
+      "crossWinRate": 0.295,
+      "crossPpg": 2.284,
+      "crossPlayed": 95,
+      "crossWins": 28,
+      "globalRating": 1124,
+      "globalMatches": 736,
+      "globalWinRate": 0.277
     },
     {
-      "name": "Conqueror_g11_755fa9",
-      "author": "claude",
-      "played": 77,
-      "wins": 20,
-      "survived": 20,
-      "points": 174,
-      "totalRank": 211,
-      "totalTerritory": 13196,
-      "totalEliminationTick": 24551,
-      "eliminationCount": 57,
-      "avgRank": 2.74025974025974,
-      "avgTerritory": 171.37662337662337,
-      "avgEliminationTick": 430.719298245614,
-      "winRate": 0.2597402597402597,
-      "survivalRate": 0.2597402597402597,
-      "pointsPerGame": 2.25974025974026,
-      "rating": 1022.38,
-      "rd": 39.63,
-      "firstEra": 5,
-      "appearances": [
-        {
-          "era": 5,
-          "rating": 1208,
-          "matches": 23
-        },
-        {
-          "era": 6,
-          "rating": 1181,
-          "matches": 43
-        },
-        {
-          "era": 7,
-          "rating": 1136,
-          "matches": 113
-        },
-        {
-          "era": 8,
-          "rating": 1124,
-          "matches": 118
-        }
-      ]
+      "rank": 4,
+      "name": "Conqueror_g17_6d0fb0",
+      "generation": 17,
+      "crossRating": 1018.17,
+      "crossWinRate": 0.257,
+      "crossPpg": 1.901,
+      "crossPlayed": 101,
+      "crossWins": 26,
+      "globalRating": 1116,
+      "globalMatches": 310,
+      "globalWinRate": 0.248
     },
     {
-      "name": "Conqueror_g8_74e11b",
-      "author": "claude",
-      "played": 66,
-      "wins": 17,
-      "survived": 17,
-      "points": 132,
-      "totalRank": 198,
-      "totalTerritory": 11215,
-      "totalEliminationTick": 19728,
-      "eliminationCount": 49,
-      "avgRank": 3,
-      "avgTerritory": 169.92424242424244,
-      "avgEliminationTick": 402.61224489795916,
-      "winRate": 0.25757575757575757,
-      "survivalRate": 0.25757575757575757,
-      "pointsPerGame": 2,
-      "rating": 1016.8,
-      "rd": 42.76,
-      "firstEra": 4,
-      "appearances": [
-        {
-          "era": 4,
-          "rating": 1178,
-          "matches": 73
-        }
-      ]
+      "rank": 5,
+      "name": "Conqueror_g9_01de66",
+      "generation": 9,
+      "crossRating": 1011.82,
+      "crossWinRate": 0.23,
+      "crossPpg": 2.04,
+      "crossPlayed": 100,
+      "crossWins": 23,
+      "globalRating": 1093,
+      "globalMatches": 25,
+      "globalWinRate": 0.36
     },
     {
-      "name": "Conqueror_g8_5c68e4",
-      "author": "claude",
-      "played": 69,
-      "wins": 18,
-      "survived": 18,
-      "points": 160,
-      "totalRank": 185,
-      "totalTerritory": 11872,
-      "totalEliminationTick": 22120,
-      "eliminationCount": 51,
-      "avgRank": 2.681159420289855,
-      "avgTerritory": 172.05797101449275,
-      "avgEliminationTick": 433.72549019607845,
-      "winRate": 0.2608695652173913,
-      "survivalRate": 0.2608695652173913,
-      "pointsPerGame": 2.318840579710145,
-      "rating": 1014.63,
-      "rd": 41.83,
-      "firstEra": 9,
-      "appearances": [
-        {
-          "era": 9,
-          "rating": 1183,
-          "matches": 32
-        }
-      ]
+      "rank": 6,
+      "name": "Conqueror_g4_be92c1",
+      "generation": 4,
+      "crossRating": 1011,
+      "crossWinRate": 0.206,
+      "crossPpg": 1.794,
+      "crossPlayed": 97,
+      "crossWins": 20,
+      "globalRating": 1079,
+      "globalMatches": 91,
+      "globalWinRate": 0.297
     },
     {
-      "name": "Conqueror_g6_27c4e7",
-      "author": "claude",
-      "played": 64,
-      "wins": 17,
-      "survived": 17,
-      "points": 149,
-      "totalRank": 171,
-      "totalTerritory": 11214,
-      "totalEliminationTick": 20829,
-      "eliminationCount": 47,
-      "avgRank": 2.671875,
-      "avgTerritory": 175.21875,
-      "avgEliminationTick": 443.17021276595744,
-      "winRate": 0.265625,
-      "survivalRate": 0.265625,
-      "pointsPerGame": 2.328125,
-      "rating": 1013.34,
-      "rd": 43.41,
-      "firstEra": 10,
-      "appearances": [
-        {
-          "era": 10,
-          "rating": 1206,
-          "matches": 27
-        }
-      ]
+      "rank": 7,
+      "name": "Conqueror_g14_8d5369",
+      "generation": 14,
+      "crossRating": 1009.26,
+      "crossWinRate": 0.255,
+      "crossPpg": 2.224,
+      "crossPlayed": 98,
+      "crossWins": 25,
+      "globalRating": 1205,
+      "globalMatches": 351,
+      "globalWinRate": 0.373
     },
     {
+      "rank": 8,
+      "name": "Conqueror_g3_be9a58",
+      "generation": 3,
+      "crossRating": 1009.17,
+      "crossWinRate": 0.207,
+      "crossPpg": 1.851,
+      "crossPlayed": 87,
+      "crossWins": 18,
+      "globalRating": 1026,
+      "globalMatches": 350,
+      "globalWinRate": 0.251
+    },
+    {
+      "rank": 9,
+      "name": "Conqueror_g15_2c15dc",
+      "generation": 15,
+      "crossRating": 1006.69,
+      "crossWinRate": 0.215,
+      "crossPpg": 2.19,
+      "crossPlayed": 79,
+      "crossWins": 17,
+      "globalRating": 1181,
+      "globalMatches": 51,
+      "globalWinRate": 0.333
+    },
+    {
+      "rank": 10,
+      "name": "Conqueror_g18_6a26b3",
+      "generation": 18,
+      "crossRating": 1004.88,
+      "crossWinRate": 0.225,
+      "crossPpg": 2.146,
+      "crossPlayed": 89,
+      "crossWins": 20,
+      "globalRating": 1132,
+      "globalMatches": 443,
+      "globalWinRate": 0.269
+    },
+    {
+      "rank": 11,
+      "name": "Conqueror_g19_9533e3",
+      "generation": 19,
+      "crossRating": 1000.91,
+      "crossWinRate": 0.241,
+      "crossPpg": 2.145,
+      "crossPlayed": 83,
+      "crossWins": 20,
+      "globalRating": 1157,
+      "globalMatches": 397,
+      "globalWinRate": 0.307
+    },
+    {
+      "rank": 12,
+      "name": "Conqueror_g16_e79590",
+      "generation": 16,
+      "crossRating": 999.66,
+      "crossWinRate": 0.17,
+      "crossPpg": 1.67,
+      "crossPlayed": 88,
+      "crossWins": 15,
+      "globalRating": 1110,
+      "globalMatches": 466,
+      "globalWinRate": 0.238
+    },
+    {
+      "rank": 13,
+      "name": "Conqueror_g12_f23241",
+      "generation": 12,
+      "crossRating": 998.1,
+      "crossWinRate": 0.212,
+      "crossPpg": 2.061,
+      "crossPlayed": 99,
+      "crossWins": 21,
+      "globalRating": 1068,
+      "globalMatches": 787,
+      "globalWinRate": 0.22
+    },
+    {
+      "rank": 14,
       "name": "Conqueror_g6_9eb2e4",
-      "author": "claude",
-      "played": 76,
-      "wins": 16,
-      "survived": 16,
-      "points": 153,
-      "totalRank": 227,
-      "totalTerritory": 10552,
-      "totalEliminationTick": 23974,
-      "eliminationCount": 60,
-      "avgRank": 2.986842105263158,
-      "avgTerritory": 138.8421052631579,
-      "avgEliminationTick": 399.56666666666666,
-      "winRate": 0.21052631578947367,
-      "survivalRate": 0.21052631578947367,
-      "pointsPerGame": 2.013157894736842,
-      "rating": 1009.91,
-      "rd": 39.89,
-      "firstEra": 2,
-      "appearances": [
-        {
-          "era": 2,
-          "rating": 1158,
-          "matches": 165
-        },
-        {
-          "era": 3,
-          "rating": 1147,
-          "matches": 243
-        },
-        {
-          "era": 4,
-          "rating": 1134,
-          "matches": 302
-        }
-      ]
+      "generation": 6,
+      "crossRating": 996.16,
+      "crossWinRate": 0.153,
+      "crossPpg": 1.824,
+      "crossPlayed": 85,
+      "crossWins": 13,
+      "globalRating": 1063,
+      "globalMatches": 566,
+      "globalWinRate": 0.309
     },
     {
-      "name": "Conqueror_g8_912a4c",
-      "author": "claude",
-      "played": 62,
-      "wins": 14,
-      "survived": 14,
-      "points": 132,
-      "totalRank": 178,
-      "totalTerritory": 9234,
-      "totalEliminationTick": 19780,
-      "eliminationCount": 48,
-      "avgRank": 2.870967741935484,
-      "avgTerritory": 148.93548387096774,
-      "avgEliminationTick": 412.0833333333333,
-      "winRate": 0.22580645161290322,
-      "survivalRate": 0.22580645161290322,
-      "pointsPerGame": 2.129032258064516,
-      "rating": 1009.82,
-      "rd": 44.1,
-      "firstEra": 5,
-      "appearances": [
-        {
-          "era": 5,
-          "rating": 1218,
-          "matches": 23
-        },
-        {
-          "era": 6,
-          "rating": 1214,
-          "matches": 43
-        }
-      ]
+      "rank": 15,
+      "name": "Conqueror_g10_34ca94",
+      "generation": 10,
+      "crossRating": 994.33,
+      "crossWinRate": 0.207,
+      "crossPpg": 1.724,
+      "crossPlayed": 87,
+      "crossWins": 18,
+      "globalRating": 1072,
+      "globalMatches": 278,
+      "globalWinRate": 0.234
     },
     {
-      "name": "Conqueror_g8_4d842b",
-      "author": "claude",
-      "played": 77,
-      "wins": 17,
-      "survived": 17,
-      "points": 167,
-      "totalRank": 218,
-      "totalTerritory": 11213,
-      "totalEliminationTick": 26397,
-      "eliminationCount": 60,
-      "avgRank": 2.831168831168831,
-      "avgTerritory": 145.62337662337663,
-      "avgEliminationTick": 439.95,
-      "winRate": 0.22077922077922077,
-      "survivalRate": 0.22077922077922077,
-      "pointsPerGame": 2.168831168831169,
-      "rating": 1007.4,
-      "rd": 39.63,
-      "firstEra": 5,
-      "appearances": [
-        {
-          "era": 5,
-          "rating": 1277,
-          "matches": 22
-        },
-        {
-          "era": 6,
-          "rating": 1207,
-          "matches": 43
-        },
-        {
-          "era": 7,
-          "rating": 1129,
-          "matches": 111
-        }
-      ]
+      "rank": 16,
+      "name": "Conqueror_g11_224717",
+      "generation": 11,
+      "crossRating": 992.42,
+      "crossWinRate": 0.185,
+      "crossPpg": 1.924,
+      "crossPlayed": 92,
+      "crossWins": 17,
+      "globalRating": 1068,
+      "globalMatches": 103,
+      "globalWinRate": 0.243
     },
     {
-      "name": "Conqueror_g10_447dc3",
-      "author": "claude",
-      "played": 58,
-      "wins": 14,
-      "survived": 14,
-      "points": 129,
-      "totalRank": 161,
-      "totalTerritory": 9231,
-      "totalEliminationTick": 19059,
-      "eliminationCount": 44,
-      "avgRank": 2.7758620689655173,
-      "avgTerritory": 159.1551724137931,
-      "avgEliminationTick": 433.15909090909093,
-      "winRate": 0.2413793103448276,
-      "survivalRate": 0.2413793103448276,
-      "pointsPerGame": 2.2241379310344827,
-      "rating": 1006.5,
-      "rd": 45.57,
-      "firstEra": 2,
-      "appearances": [
-        {
-          "era": 2,
-          "rating": 1147,
-          "matches": 33
-        },
-        {
-          "era": 3,
-          "rating": 1151,
-          "matches": 40
-        }
-      ]
+      "rank": 17,
+      "name": "Conqueror_g8_82d39b",
+      "generation": 8,
+      "crossRating": 990.83,
+      "crossWinRate": 0.17,
+      "crossPpg": 1.849,
+      "crossPlayed": 106,
+      "crossWins": 18,
+      "globalRating": 1132,
+      "globalMatches": 45,
+      "globalWinRate": 0.422
     },
     {
-      "name": "Conqueror_g5_f15d3e",
-      "author": "claude",
-      "played": 70,
-      "wins": 13,
-      "survived": 13,
-      "points": 131,
-      "totalRank": 219,
-      "totalTerritory": 8574,
-      "totalEliminationTick": 23397,
-      "eliminationCount": 57,
-      "avgRank": 3.1285714285714286,
-      "avgTerritory": 122.48571428571428,
-      "avgEliminationTick": 410.4736842105263,
-      "winRate": 0.18571428571428572,
-      "survivalRate": 0.18571428571428572,
-      "pointsPerGame": 1.8714285714285714,
-      "rating": 994.3,
-      "rd": 41.54,
-      "firstEra": 9,
-      "appearances": [
-        {
-          "era": 9,
-          "rating": 1208,
-          "matches": 40
-        },
-        {
-          "era": 10,
-          "rating": 1172,
-          "matches": 77
-        }
-      ]
+      "rank": 18,
+      "name": "Conqueror_g5_3087ea",
+      "generation": 5,
+      "crossRating": 987.38,
+      "crossWinRate": 0.159,
+      "crossPpg": 1.72,
+      "crossPlayed": 82,
+      "crossWins": 13,
+      "globalRating": 1066,
+      "globalMatches": 93,
+      "globalWinRate": 0.237
     },
     {
-      "name": "Conqueror_g9_1e065b",
-      "author": "claude",
-      "played": 82,
-      "wins": 12,
-      "survived": 12,
-      "points": 169,
-      "totalRank": 241,
-      "totalTerritory": 7913,
-      "totalEliminationTick": 30517,
-      "eliminationCount": 70,
-      "avgRank": 2.9390243902439024,
-      "avgTerritory": 96.5,
-      "avgEliminationTick": 435.95714285714286,
-      "winRate": 0.14634146341463414,
-      "survivalRate": 0.14634146341463414,
-      "pointsPerGame": 2.0609756097560976,
-      "rating": 984.13,
-      "rd": 38.42,
-      "firstEra": 4,
-      "appearances": [
-        {
-          "era": 4,
-          "rating": 1168,
-          "matches": 23
-        }
-      ]
+      "rank": 19,
+      "name": "Conqueror_g7_3b651e",
+      "generation": 7,
+      "crossRating": 987.03,
+      "crossWinRate": 0.14,
+      "crossPpg": 1.709,
+      "crossPlayed": 86,
+      "crossWins": 12,
+      "globalRating": 1056,
+      "globalMatches": 499,
+      "globalWinRate": 0.325
     },
     {
-      "name": "Conqueror_g5_897d51",
-      "author": "claude",
-      "played": 68,
-      "wins": 8,
-      "survived": 8,
-      "points": 104,
-      "totalRank": 236,
-      "totalTerritory": 5277,
-      "totalEliminationTick": 23198,
-      "eliminationCount": 60,
-      "avgRank": 3.4705882352941178,
-      "avgTerritory": 77.6029411764706,
-      "avgEliminationTick": 386.6333333333333,
-      "winRate": 0.11764705882352941,
-      "survivalRate": 0.11764705882352941,
-      "pointsPerGame": 1.5294117647058822,
-      "rating": 976.18,
-      "rd": 42.14,
-      "firstEra": 8,
-      "appearances": [
-        {
-          "era": 8,
-          "rating": 1147,
-          "matches": 43
-        }
-      ]
-    },
-    {
+      "rank": 20,
       "name": "Conqueror_g2_6b59e8",
-      "author": "claude",
-      "played": 62,
-      "wins": 7,
-      "survived": 7,
-      "points": 106,
-      "totalRank": 204,
-      "totalTerritory": 4614,
-      "totalEliminationTick": 22986,
-      "eliminationCount": 55,
-      "avgRank": 3.2903225806451615,
-      "avgTerritory": 74.41935483870968,
-      "avgEliminationTick": 417.92727272727274,
-      "winRate": 0.11290322580645161,
-      "survivalRate": 0.11290322580645161,
-      "pointsPerGame": 1.7096774193548387,
-      "rating": 975.2,
-      "rd": 44.1,
-      "firstEra": 1,
-      "appearances": [
-        {
-          "era": 1,
-          "rating": 1192,
-          "matches": 16
-        }
-      ]
+      "generation": 2,
+      "crossRating": 984.38,
+      "crossWinRate": 0.143,
+      "crossPpg": 1.67,
+      "crossPlayed": 91,
+      "crossWins": 13,
+      "globalRating": 990,
+      "globalMatches": 351,
+      "globalWinRate": 0.177
     },
     {
-      "name": "Conqueror_g5_0b2647",
-      "author": "claude",
-      "played": 65,
-      "wins": 9,
-      "survived": 9,
-      "points": 125,
-      "totalRank": 200,
-      "totalTerritory": 5938,
-      "totalEliminationTick": 24955,
-      "eliminationCount": 56,
-      "avgRank": 3.076923076923077,
-      "avgTerritory": 91.35384615384615,
-      "avgEliminationTick": 445.625,
-      "winRate": 0.13846153846153847,
-      "survivalRate": 0.13846153846153847,
-      "pointsPerGame": 1.9230769230769231,
-      "rating": 970.99,
-      "rd": 43.08,
-      "firstEra": 1,
-      "appearances": [
-        {
-          "era": 1,
-          "rating": 1204,
-          "matches": 17
-        }
-      ]
+      "rank": 21,
+      "name": "Tactician",
+      "generation": 0,
+      "crossRating": 949.05,
+      "crossWinRate": 0,
+      "crossPpg": 1.875,
+      "crossPlayed": 88,
+      "crossWins": 0,
+      "globalRating": 875,
+      "globalMatches": 887,
+      "globalWinRate": 0
     },
     {
-      "name": "Conqueror_g9_c81d7f",
-      "author": "claude",
-      "played": 65,
-      "wins": 3,
-      "survived": 3,
-      "points": 64,
-      "totalRank": 261,
-      "totalTerritory": 1979,
-      "totalEliminationTick": 21580,
-      "eliminationCount": 62,
-      "avgRank": 4.015384615384615,
-      "avgTerritory": 30.446153846153845,
-      "avgEliminationTick": 348.06451612903226,
-      "winRate": 0.046153846153846156,
-      "survivalRate": 0.046153846153846156,
-      "pointsPerGame": 0.9846153846153847,
-      "rating": 953.92,
-      "rd": 43.08,
-      "firstEra": 1,
-      "appearances": [
-        {
-          "era": 1,
-          "rating": 1179,
-          "matches": 15
-        },
-        {
-          "era": 2,
-          "rating": 1150,
-          "matches": 33
-        },
-        {
-          "era": 3,
-          "rating": 1177,
-          "matches": 40
-        }
-      ]
-    },
-    {
-      "name": "Conqueror_g8_1c5660",
-      "author": "claude",
-      "played": 71,
-      "wins": 3,
-      "survived": 3,
-      "points": 75,
-      "totalRank": 280,
-      "totalTerritory": 1978,
-      "totalEliminationTick": 24410,
-      "eliminationCount": 68,
-      "avgRank": 3.943661971830986,
-      "avgTerritory": 27.859154929577464,
-      "avgEliminationTick": 358.97058823529414,
-      "winRate": 0.04225352112676056,
-      "survivalRate": 0.04225352112676056,
-      "pointsPerGame": 1.056338028169014,
-      "rating": 951.82,
-      "rd": 41.25,
-      "firstEra": 8,
-      "appearances": [
-        {
-          "era": 8,
-          "rating": 1205,
-          "matches": 15
-        }
-      ]
+      "rank": 22,
+      "name": "Phalanx_g1_5b920f",
+      "generation": 1,
+      "crossRating": 938.87,
+      "crossWinRate": 0,
+      "crossPpg": 3,
+      "crossPlayed": 80,
+      "crossWins": 0,
+      "globalRating": 819,
+      "globalMatches": 55,
+      "globalWinRate": 0
     }
-  ]
+  ],
+  "correlations": {
+    "rhoXrXw": 0.9175607001693958,
+    "rhoXrG": 0.6487859966120836
+  },
+  "pin": {
+    "name": "Conqueror_g14_8d5369",
+    "rows": [
+      {
+        "name": "Tactician",
+        "encounters": 18,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 0,
+        "globalRating": 875
+      },
+      {
+        "name": "Phalanx_g1_5b920f",
+        "encounters": 16,
+        "wins": 4,
+        "winRate": 0.25,
+        "generation": 1,
+        "globalRating": 819
+      },
+      {
+        "name": "Conqueror_g2_6b59e8",
+        "encounters": 21,
+        "wins": 11,
+        "winRate": 0.524,
+        "generation": 2,
+        "globalRating": 990
+      },
+      {
+        "name": "Conqueror_g3_be9a58",
+        "encounters": 19,
+        "wins": 11,
+        "winRate": 0.579,
+        "generation": 3,
+        "globalRating": 1026
+      },
+      {
+        "name": "Conqueror_g4_be92c1",
+        "encounters": 19,
+        "wins": 11,
+        "winRate": 0.579,
+        "generation": 4,
+        "globalRating": 1079
+      },
+      {
+        "name": "Conqueror_g5_3087ea",
+        "encounters": 18,
+        "wins": 8,
+        "winRate": 0.444,
+        "generation": 5,
+        "globalRating": 1066
+      },
+      {
+        "name": "Conqueror_g6_9eb2e4",
+        "encounters": 18,
+        "wins": 11,
+        "winRate": 0.611,
+        "generation": 6,
+        "globalRating": 1063
+      },
+      {
+        "name": "Conqueror_g7_3b651e",
+        "encounters": 19,
+        "wins": 15,
+        "winRate": 0.789,
+        "generation": 7,
+        "globalRating": 1056
+      },
+      {
+        "name": "Conqueror_g8_82d39b",
+        "encounters": 16,
+        "wins": 9,
+        "winRate": 0.563,
+        "generation": 8,
+        "globalRating": 1132
+      },
+      {
+        "name": "Conqueror_g9_01de66",
+        "encounters": 22,
+        "wins": 17,
+        "winRate": 0.773,
+        "generation": 9,
+        "globalRating": 1093
+      },
+      {
+        "name": "Conqueror_g10_34ca94",
+        "encounters": 20,
+        "wins": 12,
+        "winRate": 0.6,
+        "generation": 10,
+        "globalRating": 1072
+      },
+      {
+        "name": "Conqueror_g11_224717",
+        "encounters": 18,
+        "wins": 8,
+        "winRate": 0.444,
+        "generation": 11,
+        "globalRating": 1068
+      },
+      {
+        "name": "Conqueror_g12_f23241",
+        "encounters": 24,
+        "wins": 17,
+        "winRate": 0.708,
+        "generation": 12,
+        "globalRating": 1068
+      },
+      {
+        "name": "Conqueror_g13_b41df9",
+        "encounters": 20,
+        "wins": 9,
+        "winRate": 0.45,
+        "generation": 13,
+        "globalRating": 1124
+      },
+      {
+        "name": "Conqueror_g15_2c15dc",
+        "encounters": 13,
+        "wins": 8,
+        "winRate": 0.615,
+        "generation": 15,
+        "globalRating": 1181
+      },
+      {
+        "name": "Conqueror_g16_e79590",
+        "encounters": 23,
+        "wins": 13,
+        "winRate": 0.565,
+        "generation": 16,
+        "globalRating": 1110
+      },
+      {
+        "name": "Conqueror_g17_6d0fb0",
+        "encounters": 21,
+        "wins": 14,
+        "winRate": 0.667,
+        "generation": 17,
+        "globalRating": 1116
+      },
+      {
+        "name": "Conqueror_g18_6a26b3",
+        "encounters": 19,
+        "wins": 10,
+        "winRate": 0.526,
+        "generation": 18,
+        "globalRating": 1132
+      },
+      {
+        "name": "Conqueror_g19_9533e3",
+        "encounters": 14,
+        "wins": 4,
+        "winRate": 0.286,
+        "generation": 19,
+        "globalRating": 1157
+      },
+      {
+        "name": "Conqueror_g20_43253a",
+        "encounters": 16,
+        "wins": 6,
+        "winRate": 0.375,
+        "generation": 20,
+        "globalRating": 1151
+      },
+      {
+        "name": "Conqueror_g21_e2aa5a",
+        "encounters": 18,
+        "wins": 9,
+        "winRate": 0.5,
+        "generation": 21,
+        "globalRating": 1095
+      }
+    ],
+    "totalEnc": 392,
+    "totalWin": 218,
+    "overallWinRate": 0.556
+  }
 }

--- a/tournament/exp-drumline-pool.js
+++ b/tournament/exp-drumline-pool.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// One-shot: how does Drumline rank against the full active pool
+// (STRATEGY_LIST, ~60 bots), under regular-ranking semantics?
+//
+// Mirrors the global ranking pipeline — runRatingTournament with K=5 on
+// lab1, then PL fit — but runs in-memory only. No matches.jsonl writes,
+// no rankings.json clobber. Reports cross-pool standings + Drumline's
+// pairwise winrate vs every opponent it shared a match with.
+
+import { STRATEGY_LIST, ALL_STRATEGIES } from "../src/strategies/index.js";
+import { MAPS } from "./maps.js";
+import { runRatingTournament } from "./scheduler.js";
+import { loadRankings, priorMap } from "./rankingsStore.js";
+
+const TARGET = "Drumline";
+const MATCHES = parseInt(process.argv[2] ?? "1500", 10);
+const SEED = parseInt(process.argv[3] ?? "1", 10);
+
+const map = MAPS.lab1;
+const strategies = STRATEGY_LIST.slice();
+console.log(`Active pool: ${strategies.length} bots. Target: ${TARGET}.`);
+console.log(`Running ${MATCHES} K=5 matches on ${map.name}, seed=${SEED}.`);
+const seedRankings = await loadRankings();
+const priors = seedRankings ? priorMap(seedRankings) : null;
+console.log(`Priors loaded: ${priors ? Object.keys(priors).length + " bots" : "none"}`);
+
+const pairWin = new Map();
+const pairEnc = new Map();
+for (const s of strategies) {
+  pairWin.set(s.name, new Map());
+  pairEnc.set(s.name, new Map());
+}
+function bumpPair(a, b, aWon) {
+  pairEnc.get(a).set(b, (pairEnc.get(a).get(b) ?? 0) + 1);
+  if (aWon) pairWin.get(a).set(b, (pairWin.get(a).get(b) ?? 0) + 1);
+}
+
+const t0 = Date.now();
+const result = runRatingTournament({
+  strategies,
+  map,
+  poolSize: map.players ?? 5,
+  matches: MATCHES,
+  baseSeed: SEED,
+  maxTicks: 4000,
+  priors,
+  onMatch: (mi, matchResult) => {
+    const order = matchResult.ranking.map((r) => r.strategy);
+    for (let i = 0; i < order.length; i++) {
+      for (let j = 0; j < order.length; j++) {
+        if (i === j) continue;
+        bumpPair(order[i], order[j], i < j);
+      }
+    }
+    if ((mi + 1) % 100 === 0) {
+      const dt = ((Date.now() - t0) / 1000).toFixed(0);
+      console.log(`  ${mi + 1}/${MATCHES}  [${dt}s]`);
+    }
+  },
+});
+const dt = ((Date.now() - t0) / 1000).toFixed(1);
+console.log(`Done in ${dt}s.\n`);
+
+// Standings: cross-pool rating + global rating side-by-side.
+const annotated = result.standings.map((s, i) => {
+  const prior = priors?.[s.name];
+  return {
+    rank: i + 1,
+    name: s.name,
+    crossRating: s.rating,
+    crossWinRate: +(s.winRate ?? 0).toFixed(3),
+    crossPpg: +s.pointsPerGame.toFixed(3),
+    crossPlayed: s.played,
+    crossWins: s.wins,
+    globalRating: prior?.rating ?? null,
+    globalPlayed: prior?.played ?? null,
+  };
+});
+
+console.log(`Cross-pool standings (top 30 + Drumline):`);
+console.log(`  rank   xRating  xWin%   xPlayed | gRating  gPlayed  bot`);
+const targetRow = annotated.find((r) => r.name === TARGET);
+const top30 = annotated.slice(0, 30);
+const view = top30.find((r) => r.name === TARGET) ? top30 : [...top30, targetRow];
+for (const r of view) {
+  const tag = r.name === TARGET ? " <== TARGET" : "";
+  console.log(
+    `  ${String(r.rank).padStart(3)}.  ${String(r.crossRating).padStart(7)}  ` +
+    `${(100 * r.crossWinRate).toFixed(1).padStart(5)}  ${String(r.crossPlayed).padStart(5)}  | ` +
+    `${String(r.globalRating ?? "-").padStart(5)}    ${String(r.globalPlayed ?? "-").padStart(5)}    ${r.name}${tag}`,
+  );
+}
+
+// Spearman correlations.
+function spearman(items, keyA, keyB) {
+  const N = items.length;
+  if (N < 2) return null;
+  const byA = items.slice().sort((a, b) => b[keyA] - a[keyA]);
+  const byB = items.slice().sort((a, b) => b[keyB] - a[keyB]);
+  const rA = new Map(), rB = new Map();
+  byA.forEach((r, i) => rA.set(r.name, i + 1));
+  byB.forEach((r, i) => rB.set(r.name, i + 1));
+  let d2 = 0;
+  for (const r of items) d2 += (rA.get(r.name) - rB.get(r.name)) ** 2;
+  return 1 - (6 * d2) / (N * (N * N - 1));
+}
+const rhoXrXw = spearman(annotated, "crossRating", "crossWinRate");
+const annotatedWithG = annotated.filter((r) => r.globalRating != null);
+const rhoXrG = spearman(annotatedWithG, "crossRating", "globalRating");
+console.log(`\nSpearman:`);
+console.log(`  cross rating vs cross winRate : ${rhoXrXw?.toFixed(3) ?? "-"}`);
+console.log(`  cross rating vs global rating : ${rhoXrG?.toFixed(3) ?? "-"}`);
+
+// Drumline pairwise.
+if (targetRow) {
+  console.log(`\n${TARGET} pairwise winrate (sorted by global rating, descending):`);
+  console.log(`  gRating  enc  wins  win%   opponent`);
+  const enc = pairEnc.get(TARGET);
+  const wins = pairWin.get(TARGET);
+  const rows = [];
+  for (const [opp, n] of enc.entries()) {
+    const w = wins.get(opp) ?? 0;
+    rows.push({
+      name: opp,
+      enc: n,
+      wins: w,
+      winRate: n ? w / n : 0,
+      gRating: priors?.[opp]?.rating ?? null,
+    });
+  }
+  rows.sort((a, b) => (b.gRating ?? 0) - (a.gRating ?? 0));
+  let totalEnc = 0, totalWin = 0;
+  for (const r of rows) {
+    totalEnc += r.enc;
+    totalWin += r.wins;
+    console.log(
+      `  ${String(r.gRating ?? "-").padStart(5)}    ${String(r.enc).padStart(3)}  ${String(r.wins).padStart(4)}  ${(100 * r.winRate).toFixed(1).padStart(5)}  ${r.name}`,
+    );
+  }
+  const overall = totalEnc ? totalWin / totalEnc : 0;
+  console.log(`  ----  overall: ${totalWin}/${totalEnc} = ${(100 * overall).toFixed(1)}% pairwise wins`);
+}

--- a/tournament/exp-lanchester.js
+++ b/tournament/exp-lanchester.js
@@ -24,6 +24,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 function parseArgs(argv) {
   const opts = {
     model: "linear",
+    movement: "classic",
     matches: 1000,
     seed: 1,
     out: null,
@@ -36,6 +37,7 @@ function parseArgs(argv) {
     const next = () => argv[++i];
     switch (a) {
       case "--model": opts.model = next(); break;
+      case "--movement": opts.movement = next(); break;
       case "--matches": opts.matches = parseInt(next(), 10); break;
       case "--seed": opts.seed = parseInt(next(), 10); break;
       case "--out": opts.out = next(); break;
@@ -65,10 +67,10 @@ async function runOne(opts) {
   const baseMap = MAPS[opts.map];
   const map = {
     ...baseMap,
-    config: { ...baseMap.config, combatModel: opts.model },
+    config: { ...baseMap.config, combatModel: opts.model, movementModel: opts.movement },
   };
   const strategies = STRATEGY_LIST.slice();
-  console.log(`Field: ${strategies.length} bots. Model: ${opts.model}.`);
+  console.log(`Field: ${strategies.length} bots. Combat: ${opts.model}. Movement: ${opts.movement}.`);
   console.log(`${opts.matches} K=${opts.pool} matches on ${opts.map}, seed=${opts.seed}.`);
   const seedRankings = await loadRankings();
   const priors = seedRankings ? priorMap(seedRankings) : null;

--- a/tournament/exp-lanchester.js
+++ b/tournament/exp-lanchester.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+// Compare bot performance under different combat models.
+//
+// Usage:
+//   node tournament/exp-lanchester.js --model linear --matches 1000 --seed 1
+//   node tournament/exp-lanchester.js --model lanchester --matches 1000 --seed 1
+//   node tournament/exp-lanchester.js --compare lin.json lan.json
+//
+// Writes a JSON output per run for later --compare aggregation. Uses
+// the active pool (STRATEGY_LIST, ~60 bots) as the field, K=5 lab1.
+// Matches run in-memory only; matches.jsonl + rankings.json are not
+// touched.
+
+import { STRATEGY_LIST } from "../src/strategies/index.js";
+import { MAPS } from "./maps.js";
+import { runRatingTournament } from "./scheduler.js";
+import { loadRankings, priorMap } from "./rankingsStore.js";
+import { writeFile, readFile } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(argv) {
+  const opts = {
+    model: "linear",
+    matches: 1000,
+    seed: 1,
+    out: null,
+    compare: null,
+    pool: 5,
+    map: "lab1",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    const next = () => argv[++i];
+    switch (a) {
+      case "--model": opts.model = next(); break;
+      case "--matches": opts.matches = parseInt(next(), 10); break;
+      case "--seed": opts.seed = parseInt(next(), 10); break;
+      case "--out": opts.out = next(); break;
+      case "--compare": opts.compare = [next(), next()]; break;
+      case "--pool": opts.pool = parseInt(next(), 10); break;
+      case "--map": opts.map = next(); break;
+      default: throw new Error(`Unknown option: ${a}`);
+    }
+  }
+  return opts;
+}
+
+function spearman(items, keyA, keyB) {
+  const N = items.length;
+  if (N < 2) return null;
+  const byA = items.slice().sort((a, b) => b[keyA] - a[keyA]);
+  const byB = items.slice().sort((a, b) => b[keyB] - a[keyB]);
+  const rA = new Map(), rB = new Map();
+  byA.forEach((r, i) => rA.set(r.name, i + 1));
+  byB.forEach((r, i) => rB.set(r.name, i + 1));
+  let d2 = 0;
+  for (const r of items) d2 += (rA.get(r.name) - rB.get(r.name)) ** 2;
+  return 1 - (6 * d2) / (N * (N * N - 1));
+}
+
+async function runOne(opts) {
+  const baseMap = MAPS[opts.map];
+  const map = {
+    ...baseMap,
+    config: { ...baseMap.config, combatModel: opts.model },
+  };
+  const strategies = STRATEGY_LIST.slice();
+  console.log(`Field: ${strategies.length} bots. Model: ${opts.model}.`);
+  console.log(`${opts.matches} K=${opts.pool} matches on ${opts.map}, seed=${opts.seed}.`);
+  const seedRankings = await loadRankings();
+  const priors = seedRankings ? priorMap(seedRankings) : null;
+
+  const pairWin = new Map();
+  const pairEnc = new Map();
+  for (const s of strategies) {
+    pairWin.set(s.name, new Map());
+    pairEnc.set(s.name, new Map());
+  }
+
+  const t0 = Date.now();
+  const result = runRatingTournament({
+    strategies,
+    map,
+    poolSize: opts.pool,
+    matches: opts.matches,
+    baseSeed: opts.seed,
+    maxTicks: 4000,
+    priors,
+    onMatch: (mi, matchResult) => {
+      const order = matchResult.ranking.map((r) => r.strategy);
+      for (let i = 0; i < order.length; i++) {
+        for (let j = 0; j < order.length; j++) {
+          if (i === j) continue;
+          const a = order[i], b = order[j];
+          pairEnc.get(a).set(b, (pairEnc.get(a).get(b) ?? 0) + 1);
+          if (i < j) pairWin.get(a).set(b, (pairWin.get(a).get(b) ?? 0) + 1);
+        }
+      }
+      if ((mi + 1) % 100 === 0) {
+        const dt = ((Date.now() - t0) / 1000).toFixed(0);
+        console.log(`  ${mi + 1}/${opts.matches}  [${dt}s]`);
+      }
+    },
+  });
+  const dt = ((Date.now() - t0) / 1000).toFixed(1);
+  console.log(`Done in ${dt}s.\n`);
+
+  const standings = result.standings.map((s, i) => ({
+    rank: i + 1,
+    name: s.name,
+    rating: s.rating,
+    winRate: +(s.winRate ?? 0).toFixed(3),
+    ppg: +s.pointsPerGame.toFixed(3),
+    played: s.played,
+    wins: s.wins,
+    globalRating: priors?.[s.name]?.rating ?? null,
+  }));
+
+  console.log(`Top 20 (model=${opts.model}):`);
+  console.log(`  rank  rating  win%   played | gRating  bot`);
+  for (const r of standings.slice(0, 20)) {
+    console.log(
+      `  ${String(r.rank).padStart(3)}.  ${String(r.rating).padStart(5)}  ${(100 * r.winRate).toFixed(1).padStart(5)}  ${String(r.played).padStart(5)}  | ${String(r.globalRating ?? "-").padStart(5)}  ${r.name}`,
+    );
+  }
+
+  // Drumline-specific pairwise (sorted by global rating).
+  const drumEnc = pairEnc.get("Drumline");
+  const drumWin = pairWin.get("Drumline");
+  let drumlineRow = null;
+  if (drumEnc) {
+    const rows = [];
+    for (const [opp, n] of drumEnc.entries()) {
+      const w = drumWin.get(opp) ?? 0;
+      rows.push({
+        name: opp,
+        encounters: n,
+        wins: w,
+        winRate: n ? +(w / n).toFixed(3) : 0,
+        globalRating: priors?.[opp]?.rating ?? null,
+      });
+    }
+    rows.sort((a, b) => (b.globalRating ?? 0) - (a.globalRating ?? 0));
+    let totalEnc = 0, totalWin = 0;
+    for (const r of rows) { totalEnc += r.encounters; totalWin += r.wins; }
+    drumlineRow = {
+      rows,
+      totalEnc,
+      totalWin,
+      overall: totalEnc ? totalWin / totalEnc : 0,
+    };
+    console.log(`\nDrumline overall pairwise: ${totalWin}/${totalEnc} = ${(100 * drumlineRow.overall).toFixed(1)}%`);
+  }
+
+  const rhoR = spearman(standings, "rating", "winRate");
+  const rhoG = spearman(standings.filter((r) => r.globalRating != null), "rating", "globalRating");
+  console.log(`Spearman rho(rating, winRate)=${rhoR?.toFixed(3) ?? "-"}, rho(rating, global)=${rhoG?.toFixed(3) ?? "-"}`);
+
+  const outPath = opts.out ?? resolve(HERE, `exp-lanchester-${opts.model}.json`);
+  await writeFile(outPath, JSON.stringify({
+    generatedAt: new Date().toISOString(),
+    opts,
+    standings,
+    drumline: drumlineRow,
+    correlations: { rhoRatingWinRate: rhoR, rhoRatingGlobal: rhoG },
+  }, null, 2) + "\n", "utf8");
+  console.log(`Wrote ${outPath}`);
+  return outPath;
+}
+
+async function compare(pathA, pathB) {
+  const A = JSON.parse(await readFile(pathA, "utf8"));
+  const B = JSON.parse(await readFile(pathB, "utf8"));
+  const labelA = A.opts.model;
+  const labelB = B.opts.model;
+  console.log(`Compare ${labelA} (${pathA}) vs ${labelB} (${pathB})`);
+
+  const rankA = new Map(A.standings.map((r) => [r.name, r.rank]));
+  const ratingA = new Map(A.standings.map((r) => [r.name, r.rating]));
+  const rankB = new Map(B.standings.map((r) => [r.name, r.rank]));
+  const ratingB = new Map(B.standings.map((r) => [r.name, r.rating]));
+
+  // Spearman rho between the two rankings (full overlap).
+  const names = [...rankA.keys()].filter((n) => rankB.has(n));
+  let d2 = 0;
+  for (const n of names) d2 += (rankA.get(n) - rankB.get(n)) ** 2;
+  const N = names.length;
+  const rho = 1 - (6 * d2) / (N * (N * N - 1));
+  console.log(`Spearman rho between rankings: ${rho.toFixed(3)} (${N} bots)`);
+
+  // Biggest movers.
+  const moves = names.map((n) => ({
+    name: n,
+    delta: rankA.get(n) - rankB.get(n),  // positive = climbed under model B
+    ratingA: ratingA.get(n),
+    ratingB: ratingB.get(n),
+    rankA: rankA.get(n),
+    rankB: rankB.get(n),
+  }));
+  moves.sort((a, b) => b.delta - a.delta);
+  console.log(`\nBiggest climbers (${labelA} -> ${labelB}, +Δ = climbed):`);
+  for (const m of moves.slice(0, 10)) {
+    console.log(`  +${String(m.delta).padStart(2)}  ${labelA} #${String(m.rankA).padStart(2)} (${m.ratingA}) -> ${labelB} #${String(m.rankB).padStart(2)} (${m.ratingB})  ${m.name}`);
+  }
+  console.log(`\nBiggest fallers:`);
+  for (const m of moves.slice(-10).reverse()) {
+    console.log(`  ${String(m.delta).padStart(3)}  ${labelA} #${String(m.rankA).padStart(2)} (${m.ratingA}) -> ${labelB} #${String(m.rankB).padStart(2)} (${m.ratingB})  ${m.name}`);
+  }
+
+  // Drumline change.
+  if (A.drumline && B.drumline) {
+    console.log(`\nDrumline:`);
+    console.log(`  ${labelA}:    rank ${rankA.get("Drumline")}, rating ${ratingA.get("Drumline")}, pairwise ${(100 * A.drumline.overall).toFixed(1)}%`);
+    console.log(`  ${labelB}:    rank ${rankB.get("Drumline")}, rating ${ratingB.get("Drumline")}, pairwise ${(100 * B.drumline.overall).toFixed(1)}%`);
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.compare) {
+    await compare(opts.compare[0], opts.compare[1]);
+    return;
+  }
+  if (opts.model !== "linear" && opts.model !== "lanchester") {
+    throw new Error(`--model must be linear or lanchester, got ${opts.model}`);
+  }
+  await runOne(opts);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tournament/exp-lanchester.js
+++ b/tournament/exp-lanchester.js
@@ -134,7 +134,7 @@ async function runOne(opts) {
   // encounters/wins across the field, so we can compare apples to
   // apples even when their played-counts differ from matchmaker
   // info-gain anchoring.
-  const targets = ["Drumline", "Sniper", "Hammer", "Stockpile"];
+  const targets = ["Drumline", "Sniper", "Hammer", "Stockpile", "Reservoir"];
   const targetSummaries = {};
   for (const tname of targets) {
     const enc = pairEnc.get(tname);

--- a/tournament/exp-lanchester.js
+++ b/tournament/exp-lanchester.js
@@ -129,33 +129,40 @@ async function runOne(opts) {
     );
   }
 
-  // Drumline-specific pairwise (sorted by global rating).
-  const drumEnc = pairEnc.get("Drumline");
-  const drumWin = pairWin.get("Drumline");
-  let drumlineRow = null;
-  if (drumEnc) {
+  // Pairwise summaries for the named candidate bots (the ones we're
+  // actually evaluating, which won't have priors). Each gets total
+  // encounters/wins across the field, so we can compare apples to
+  // apples even when their played-counts differ from matchmaker
+  // info-gain anchoring.
+  const targets = ["Drumline", "Sniper", "Hammer", "Stockpile"];
+  const targetSummaries = {};
+  for (const tname of targets) {
+    const enc = pairEnc.get(tname);
+    if (!enc) continue;
+    const wins = pairWin.get(tname);
+    let totalEnc = 0, totalWin = 0;
     const rows = [];
-    for (const [opp, n] of drumEnc.entries()) {
-      const w = drumWin.get(opp) ?? 0;
+    for (const [opp, n] of enc.entries()) {
+      const w = wins.get(opp) ?? 0;
+      totalEnc += n;
+      totalWin += w;
       rows.push({
         name: opp,
         encounters: n,
         wins: w,
         winRate: n ? +(w / n).toFixed(3) : 0,
-        globalRating: priors?.[opp]?.rating ?? null,
       });
     }
-    rows.sort((a, b) => (b.globalRating ?? 0) - (a.globalRating ?? 0));
-    let totalEnc = 0, totalWin = 0;
-    for (const r of rows) { totalEnc += r.encounters; totalWin += r.wins; }
-    drumlineRow = {
+    rows.sort((a, b) => b.encounters - a.encounters);
+    targetSummaries[tname] = {
       rows,
       totalEnc,
       totalWin,
       overall: totalEnc ? totalWin / totalEnc : 0,
     };
-    console.log(`\nDrumline overall pairwise: ${totalWin}/${totalEnc} = ${(100 * drumlineRow.overall).toFixed(1)}%`);
+    console.log(`${tname} pairwise: ${totalWin}/${totalEnc} = ${(100 * targetSummaries[tname].overall).toFixed(1)}%`);
   }
+  const drumlineRow = targetSummaries["Drumline"] ?? null;
 
   const rhoR = spearman(standings, "rating", "winRate");
   const rhoG = spearman(standings.filter((r) => r.globalRating != null), "rating", "globalRating");
@@ -167,6 +174,7 @@ async function runOne(opts) {
     opts,
     standings,
     drumline: drumlineRow,
+    targets: targetSummaries,
     correlations: { rhoRatingWinRate: rhoR, rhoRatingGlobal: rhoG },
   }, null, 2) + "\n", "utf8");
   console.log(`Wrote ${outPath}`);


### PR DESCRIPTION
## Summary
Refactored the cross-era tournament system from timestamp-based interval slicing to generation-based bucketing, enabling cleaner era tracking independent of match log density. Added four new experimental strategy variants and infrastructure for testing alternative combat/movement models.

## Key Changes

### Core Tournament Refactoring
- **Generation-based eras**: Replaced `intervals` parameter with generation bucketing via lineage data. Each generation (e.g., `Conqueror_gN_*`) now represents one era, eliminating dependency on `matches.jsonl` timestamps.
- **Simplified options**: Removed `--intervals` flag; added `--pin` to inject specific bots (e.g., fresh candidates) into cross-era evaluation. Changed `minPlayedInEra` → `minPlayed` for clarity.
- **Cleaner output**: Eras now keyed by `generation` field; standings include `crossRating`, `crossWinRate`, `crossPpg` metrics alongside global stats.

### New Experimental Strategies
Four new bots exploring alternative tactics on the Conqueror_g13 chassis:
- **Drumline**: Injects wave-direction tiebreaker into kill selection. Computes opponent center-of-mass and biases adjacent kills toward the nearest threat for coordinated frontier pushes.
- **Sniper**: Opportunistic ranged strikes when no adjacent kill is available and home tile has surplus strength. Validates targets for clean Lanchester wins before committing.
- **Hammer**: Max-commit variant—commits full `attackPower` instead of min-overkill. Exploits Lanchester's sqrt-based surplus preservation and cost-formula's fixed +1 overhead.
- **Stockpile**: Interior idle + ranged alpha strikes. Frontier tiles defer to chassis; interior tiles wait for budget cap, then teleport strikes at vulnerable enemies in range.
- **Reservoir**: Strict upgrade—idles on "wasted" ticks (no enemy, no empty neighbor, all friendly neighbors maxed) to avoid +1 move overhead.

### Combat & Movement Model Infrastructure
- **Lanchester combat model**: Added `combatModel` option ("linear" vs "lanchester"). Lanchester uses `sqrt(winner_eff² - loser_eff²)` post-fight strength, rewarding force concentration.
- **Budget movement mode**: New `movementModel` ("classic" vs "budget"). Budget mode enforces per-tile work-unit caps (`strength × distance`), recharging per tick via move-tech multiplier. Garrison floor drops to 0.5 (engine minimum) instead of player-derived floor.
- **Experimental harness**: `exp-lanchester.js` runs isolated tournaments under different combat/movement configs; `exp-drumline-pool.js` evaluates Drumline against the full active pool.

### Army & Tile Updates
- **Army.attackPower**: Now respects `movementModel`—uses 0.5 floor in budget mode, player's `minGarrison` in classic mode.
- **Army._distance()**: Added wrap-aware Euclidean distance helper for budget-mode work calculations.
- **Tile.budget**: New per-tile movement budget field, recharges per tick, resets on conquest.

## Implementation Details
- Generation bucketing reads `lineages.json` to map bot names to generations, then buckets rankings by generation and selects top-N per era.
- Spearman correlation between cross-era rating and cross-era win-rate quantifies how well rating tracks raw dominance.
- Experimental bots inherit from validated parents (mostly Conqueror_g13_b41df9) to ensure fallback behavior is sound; new logic gates on specific conditions (e.g., "no adjacent kill available") so upgrades are strict.
- Budget mode's per-tile cap prevents runaway strength transfers; cost formula `power × distance + 1` makes large moves cheaper per delivered strength when distance is fixed.

https://claude.ai/code/session_013NcshLkHSoFSsridqQCWVJ