### PR TITLE
Add three new bot strategies: Convex, Cleaver, and Coward

### DIFF
--- a/src/strategies/Cleaver.js
+++ b/src/strategies/Cleaver.js
@@ -1,0 +1,83 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+export default {
+  name: "Cleaver",
+  author: "claude",
+  version: 1,
+  description: "Picks off the most isolated adjacent enemy — the one with the fewest friends nearby.",
+  summary: `Convex's mirror twin. Where Convex scores by friendly
+support around the target, Cleaver scores by *lack of enemy
+support*. The intuition: an enemy stack with three more enemy
+stacks adjacent to it is going to get reinforced even if we win
+the capture, so the kill is wasted overhead. An enemy stack
+isolated in our half of the board has nowhere to retreat to and
+nothing to reinforce it — that's the one to kill.
+
+Per army:
+  1. For each adjacent enemy stack we can beat (enemyTotal + 1 <
+     strength), look at the target tile's three other neighbors
+     and sum enemy strength on those tiles (the "backup").
+  2. Score = enemy - 1.2 * backup. Big enemy with low backup
+     scores best; a fat enemy with three fat enemies behind it is
+     scored the same as a small isolated enemy and we'd rather
+     pick the small isolated one.
+  3. If no qualifying kill, fall through to SlowAndSteady.
+
+Strength: a natural counter to Phalanx-style "thick line" bots.
+Cleaver bypasses the line center and chews on whichever flank
+tile has the least backup, peeling the line apart over several
+ticks.
+
+Weakness: when the entire board is contested and every enemy has
+backup, Cleaver's scorer ranks all candidates roughly equal and
+behaves like a noisy SlowAndSteady. Doesn't shine until the
+midgame when frontiers form.`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) {
+      SlowAndSteady.act(army, game);
+      return;
+    }
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    let best = null;
+    let bestScore = -Infinity;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) continue;
+      if (enemy <= 0) continue;
+      if (enemy + 1 >= army.strength) continue;
+
+      const tn = t.neighbors;
+      let backup = 0;
+      for (let j = 0; j < 4; j++) {
+        const tt = tn[j];
+        if (!tt || tt === tile) continue;
+        const ttArmies = tt.armies;
+        for (let k = 0; k < ttArmies.length; k++) {
+          const a = ttArmies[k];
+          if (a.player.id !== pid) backup += a.strength;
+        }
+      }
+      const score = enemy - 1.2 * backup;
+      if (score > bestScore) {
+        bestScore = score;
+        best = t;
+      }
+    }
+    if (best) {
+      army.attack(best, army.attackPower);
+      return;
+    }
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Convex.js
+++ b/src/strategies/Convex.js
@@ -1,0 +1,83 @@
+import SlowAndSteady from "./SlowAndSteady.js";
+
+export default {
+  name: "Convex",
+  author: "claude",
+  version: 1,
+  description: "Prefers captures whose target tile is already ringed by friendlies — sticky gains over flashy ones.",
+  summary: `Most kill-scoring bots ask "can I beat this stack?" and stop
+there. Convex asks the follow-up: "and will I still own that tile
+next tick?" A capture surrounded by friendly tiles is essentially
+free territory; a capture surrounded by enemy tiles is a one-tick
+salient that gets retaken before it produces anything.
+
+Per army:
+  1. For each adjacent enemy stack we can beat (enemyTotal + 1 <
+     strength), look at the target tile's three other neighbors.
+     Count friendly armies (positive support) and sum enemy
+     strength (negative support).
+  2. Score = 2 * friendlySupport - 1.5 * outerEnemy - 0.1 * enemy.
+     The friendly bonus is the headline; the outer-enemy penalty
+     vetoes one-tick salients; the small enemy term breaks ties
+     toward cheaper fights.
+  3. Best score wins, commit attackPower. No qualifying capture
+     anywhere — fall through to SlowAndSteady so we don't sit idle.
+
+Strength: pairs well with itself. Two Convex armies adjacent to a
+weak enemy will race to take it because the support score includes
+each other's tile.
+
+Weakness: passes on lonely captures even when they're huge wins,
+because no friendlies back them. A Hunter chassis would happily
+take what Convex declines.`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) {
+      SlowAndSteady.act(army, game);
+      return;
+    }
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    let best = null;
+    let bestScore = -Infinity;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) continue;
+      if (enemy <= 0) continue;
+      if (enemy + 1 >= army.strength) continue;
+
+      const tn = t.neighbors;
+      let support = 0;
+      let outerEnemy = 0;
+      for (let j = 0; j < 4; j++) {
+        const tt = tn[j];
+        if (!tt || tt === tile) continue;
+        const ttArmies = tt.armies;
+        for (let k = 0; k < ttArmies.length; k++) {
+          const a = ttArmies[k];
+          if (a.player.id === pid) support += 1;
+          else outerEnemy += a.strength;
+        }
+      }
+      const score = 2 * support - 1.5 * outerEnemy - 0.1 * enemy;
+      if (score > bestScore) {
+        bestScore = score;
+        best = t;
+      }
+    }
+    if (best) {
+      army.attack(best, army.attackPower);
+      return;
+    }
+    SlowAndSteady.act(army, game);
+  },
+};

--- a/src/strategies/Coward.js
+++ b/src/strategies/Coward.js
@@ -1,0 +1,100 @@
+import { balanceAttack } from "./helpers.js";
+
+export default {
+  name: "Coward",
+  author: "claude",
+  version: 1,
+  description: "Refuses any fight that's not a sure thing — only attacks empties or enemies it can crush at 2x.",
+  summary: `Risk-averse to a fault. The standard "can I beat them with
+margin 1" check is enough to win a duel but not enough to absorb a
+late-arriving reinforcement on the same tick — Aggressive's
+summary calls this exact failure mode out. Coward addresses it by
+only committing to fights where enemyTotal * 2 + 1 < strength.
+Anything closer than that is treated as a coin flip and declined.
+
+Per army:
+  1. Scan neighbors. If any neighbor enemy is *stronger* than us,
+     we're potentially under threat — reinforce the friendliest
+     adjacent tile (or stay put if no friendlies). No attack.
+  2. Otherwise, prefer empty neighbors first (free territory, no
+     trade). Use balanceAttack to commit just enough to hold.
+  3. Then, qualifying enemies (2x margin). Same balanceAttack:
+     send the minimum needed.
+  4. Otherwise sit and grow.
+
+Strength: nearly impossible to die by walking into a bad trade.
+Pairs well with bots that need a defensive backline (Bully,
+Conqueror lineage) — Coward holds the rear while they push.
+
+Weakness: in a tournament where Borda scoring rewards survivors
+weakly and territory leaders strongly, Coward's pacifism caps its
+ceiling. Beats Hunter (which suicides into stacked tiles) but
+loses to Settler (which compounds undisturbed because Coward
+won't pressure it).`,
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+
+    let threatened = false;
+    let bestEmpty = null;
+    let bestEnemy = null;
+    let bestEnemyScore = -Infinity;
+    let friendliest = null;
+    let friendliestCount = 0;
+
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) {
+        if (!bestEmpty) bestEmpty = t;
+        continue;
+      }
+      let enemy = 0;
+      let friendly = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendly += 1;
+        else enemy += a.strength;
+      }
+      if (friendly > 0 && enemy === 0) {
+        if (friendly > friendliestCount) {
+          friendliestCount = friendly;
+          friendliest = t;
+        }
+        continue;
+      }
+      if (enemy >= army.strength) {
+        threatened = true;
+        continue;
+      }
+      if (enemy * 2 + 1 < army.strength) {
+        const score = army.strength - enemy;
+        if (score > bestEnemyScore) {
+          bestEnemyScore = score;
+          bestEnemy = t;
+        }
+      }
+    }
+
+    if (threatened) {
+      if (friendliest && army.strength > 4) {
+        army.attack(friendliest, army.strength * 0.5);
+      }
+      return;
+    }
+    if (bestEmpty) {
+      balanceAttack(army, bestEmpty);
+      return;
+    }
+    if (bestEnemy) {
+      balanceAttack(army, bestEnemy);
+      return;
+    }
+    if (friendliest && army.strength > army.maxStrength * 0.85) {
+      army.attack(friendliest, army.strength * 0.5);
+    }
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -44,6 +44,9 @@ import Sniper from "./Sniper.js";
 import Hammer from "./Hammer.js";
 import Stockpile from "./Stockpile.js";
 import Reservoir from "./Reservoir.js";
+import Convex from "./Convex.js";
+import Cleaver from "./Cleaver.js";
+import Coward from "./Coward.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -99,6 +102,9 @@ export const ALL_STRATEGY_LIST = [
   Hammer,
   Stockpile,
   Reservoir,
+  Convex,
+  Cleaver,
+  Coward,
   ...GENERATED,
   ...DESCENDANTS,
 ];


### PR DESCRIPTION
## Summary
This PR introduces three new AI bot strategies to the game, each with distinct tactical approaches to combat and territory control.

## Key Changes
- **Convex**: A capture-scoring strategy that prioritizes enemy tiles already surrounded by friendly forces, avoiding one-tick salients that get retaken immediately. Falls back to SlowAndSteady when no qualifying captures exist.

- **Cleaver**: A mirror strategy to Convex that targets isolated enemy stacks with minimal backup support. Scores targets by enemy strength minus 1.2× the backup strength of adjacent tiles, making it effective against thick defensive lines.

- **Coward**: An extremely risk-averse strategy that only attacks when it has a 2× strength margin (enemyTotal × 2 + 1 < strength). Prioritizes empty tiles, reinforces friendlies when threatened, and serves as a defensive backline for more aggressive bots.

- Updated `src/strategies/index.js` to import and export all three new strategies in the `ALL_STRATEGY_LIST`.

## Implementation Details
- All three strategies follow the existing bot architecture with `name`, `author`, `version`, `description`, `summary`, and `act()` method.
- Convex and Cleaver both delegate to SlowAndSteady as a fallback when no qualifying targets are found, ensuring they never sit idle.
- Coward uses the existing `balanceAttack` helper for efficient resource allocation on qualifying targets.
- Each strategy includes detailed docstrings explaining their strengths, weaknesses, and tactical roles in team compositions.

https://claude.ai/code/session_01RPWCp35Q2gE8pQu8VnHvcq