### PR TITLE
Add three new Conqueror_g13 chassis variants: Beachhead, Cordon, Forge

### DIFF
--- a/src/strategies/Beachhead.js
+++ b/src/strategies/Beachhead.js
@@ -1,0 +1,172 @@
+import { sumStrength } from "../core/Army.js";
+import Parent from "./Conqueror_g13_b41df9.js";
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+const MARGIN = 0.45;
+const BACKING_WEIGHT = 0.4;
+const RETAKE_W = 0.8;
+const FRIENDLY_W = 0.4;
+const RETAKE_VETO = 1.5;
+// New term: per empty neighbor of the kill target (excluding the
+// source tile we're attacking from). Tuned conservatively so it's
+// a tiebreaker on chassis-equivalent kills, not a value override.
+const EMPTY_FLANK_W = 0.35;
+
+const HEMI = (() => {
+  const w = [], e = [], n = [], s = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const idx = i * 5 + j;
+      const dx = j - 2;
+      const dy = i - 2;
+      if (dx < 0) w.push(idx);
+      if (dx > 0) e.push(idx);
+      if (dy < 0) n.push(idx);
+      if (dy > 0) s.push(idx);
+    }
+  }
+  return [w, e, n, s];
+})();
+
+export default {
+  name: "Beachhead",
+  author: "claude",
+  version: 1,
+  description:
+    "Conqueror_g13 chassis with one Pass 1 scoring tweak: add a per-empty-flank bonus to kill scores. Captures that land with more empty neighbors create more next-tick frontage to expand into, compounding the kill's strategic value.",
+  summary: `The chassis's Pass 1 picker scores beatable kills as
+enemy + BACKING_WEIGHT*backing - RETAKE_W*backup + FRIENDLY_W*friend.
+That balances the kill's local value against how exposed the
+captured tile will be next tick. What it doesn't reward is how
+many empty (no-army) neighbors the captured tile has — those are
+free expansion options the bot will be able to take next tick at
+cost = 1*power + 1, which is the cheapest kind of action available.
+
+Beachhead adds + EMPTY_FLANK_W * empties, where empties is the
+count of empty neighbors of the target tile (excluding the source
+we're attacking from, which is friendly anyway after the move).
+EMPTY_FLANK_W = 0.35 is small enough that it never overrides a
+clear chassis preference (typical score deltas are 1-3 from the
+enemy term) but large enough to break ties: when two kills are
+otherwise equivalent, take the one that opens more frontline.
+
+Why this should be a strict upgrade:
+  - Empty flanks have no defender, so they will not resist next
+    tick; the +1 move overhead for capturing them is the cheapest
+    yield-per-strength action in the game.
+  - The captured tile becomes the source for those expansions,
+    so picking captures with more empty flanks chains kills into
+    expansions naturally — same army, same neighborhood, same
+    tick-to-tick continuity.
+  - The chassis's existing terms are preserved verbatim. Beachhead
+    only ADDS a non-negative term; ties go to better frontline
+    geometry, but the chassis's anti-retake / hemisphere-backing
+    safety stays in force.
+
+Pass 2 (Conqueror.act fallback when no kill but other target) and
+Pass 3 (stencil walk) are inherited unchanged. The thesis is local
+to the kill picker.
+
+Tech mirrors the chassis champion {move:76, stack:0, prod:16, atk:5,
+def:3} so the score-tweak delta is isolated from any tech change.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) {
+      Conqueror.act(army, game);
+      return;
+    }
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+
+    let bestKill = null;
+    let bestScore = -Infinity;
+    let bestNeeded = 0;
+    let hasOtherTarget = false;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) { hasOtherTarget = true; continue; }
+      let friendlyArmy = null;
+      let enemy = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
+      }
+      if (enemy > 0) {
+        const needed = enemy / BONUS + MARGIN;
+        if (needed > sLimit) continue;
+
+        let backup = 0;
+        let friend = 0;
+        let empties = 0;
+        const tn = t.neighbors;
+        for (let j = 0; j < 4; j++) {
+          const tt = tn[j];
+          if (!tt || tt === tile) continue;
+          const ttArmies = tt.armies;
+          if (ttArmies.length === 0) { empties++; continue; }
+          let tnE = 0;
+          let tnF = 0;
+          for (let k = 0; k < ttArmies.length; k++) {
+            const a = ttArmies[k];
+            if (a.player.id === pid) tnF += a.strength;
+            else tnE += a.strength;
+          }
+          if (tnE > backup) backup = tnE;
+          if (tnF > friend) friend = tnF;
+        }
+
+        if (backup >= RETAKE_VETO) continue;
+
+        let backing = 0;
+        if (stencil) {
+          const idxs = HEMI[i];
+          for (let k = 0; k < idxs.length; k++) {
+            const cell = stencil[idxs[k]];
+            if (!cell) continue;
+            const cArmies = cell.armies;
+            if (cArmies.length === 0) continue;
+            const e = -sumStrength(cArmies, viewer);
+            if (e > 0) backing += e;
+          }
+        }
+
+        const score = enemy
+          + BACKING_WEIGHT * backing
+          - RETAKE_W * backup
+          + FRIENDLY_W * friend
+          + EMPTY_FLANK_W * empties;
+        if (score > bestScore) {
+          bestScore = score;
+          bestNeeded = needed;
+          bestKill = t;
+        }
+        continue;
+      }
+      if (friendlyArmy && friendlyArmy.strength < friendlyArmy.maxStrength - 0.5) {
+        hasOtherTarget = true;
+      }
+    }
+    if (bestKill) {
+      army.attack(bestKill, bestNeeded);
+      return;
+    }
+
+    // No kill found — defer to the chassis for Pass 2 / Pass 3.
+    // Beachhead's thesis is purely about kill-target picking;
+    // expansion / reinforce / stencil-walk fallbacks stay verbatim.
+    if (hasOtherTarget) {
+      Conqueror.act(army, game);
+      return;
+    }
+    Parent.act(army, game);
+  },
+};

--- a/src/strategies/Cordon.js
+++ b/src/strategies/Cordon.js
@@ -1,0 +1,95 @@
+import Parent from "./Conqueror_g13_b41df9.js";
+
+const BONUS = 1.4;
+const MARGIN = 0.45;
+// Below this attackPower, even a successful empty-tile capture
+// lands with so little strength behind it that it's trivially
+// retaken — and the +1 move overhead is paid in full regardless.
+// 1.8 keeps Pass 1 kills (which gate on enemy/BONUS+MARGIN <= sLimit
+// anyway) intact, but skips the inefficient "spend 1.5 to take an
+// empty tile that lands with 0.5 strength" branch.
+const WEAK_LIMIT = 1.8;
+
+function hasBeatableAdjacentEnemy(tile, pid, sLimit) {
+  const n = tile.neighbors;
+  for (let i = 0; i < 4; i++) {
+    const t = n[i];
+    if (!t) continue;
+    const armies = t.armies;
+    if (armies.length === 0) continue;
+    let friendly = false;
+    let enemy = 0;
+    for (let k = 0; k < armies.length; k++) {
+      const a = armies[k];
+      if (a.player.id === pid) { friendly = true; break; }
+      enemy += a.strength;
+    }
+    if (friendly) continue;
+    if (enemy > 0 && enemy / BONUS + MARGIN <= sLimit) return true;
+  }
+  return false;
+}
+
+export default {
+  name: "Cordon",
+  author: "claude",
+  version: 1,
+  description:
+    "Conqueror_g13 chassis with one strict-upgrade gate: when the army's attackPower is below a weak-action threshold and no adjacent enemy is beatable, idle. Saves the +1 move overhead on ticks where the chassis would otherwise spend it on a near-zero-yield expansion.",
+  summary: `Cost formula on this ruleset is power*distance + 1. A move
+of 1.5 strength to an empty adjacent tile costs 2.5 work and lands
+with 0.5 strength on the captured tile (the rest is overhead). The
+capture is real but the resulting tile is below the retake threshold
+of any adjacent enemy with > 0.5 strength — the +1 overhead bought
+nothing durable.
+
+Reservoir already idles on the specific case where every neighbor
+is a maxed friendly. Cordon addresses the complementary case: the
+army itself is too weak to do anything efficient, regardless of
+what's adjacent. Concretely:
+
+  1. If sLimit (army.attackPower) >= WEAK_LIMIT (1.8), defer to
+     chassis verbatim. The chassis is well-tuned for normal-strength
+     actions and we don't want to second-guess it.
+  2. If sLimit < 1.8 AND any adjacent enemy is beatable per the
+     chassis's own gate (enemy/1.4 + 0.45 <= sLimit), defer — the
+     kill is real and worth the move overhead even at low strength.
+  3. Otherwise (weak source, no winnable adjacent kill), idle.
+     Whatever Conqueror.act would have done — capture an empty,
+     reinforce a friendly with a tiny topup — the +1 overhead
+     is dominant and the result is fragile. Holding lets the tile
+     accumulate one more tick of growth, so by next tick we
+     either clear WEAK_LIMIT (back to chassis) or remain idle for
+     another tick at zero cost. Either is dominated by paying the
+     overhead now.
+
+Why this is a strict upgrade rather than a different bot:
+  - Pass 1 kills (the chassis's main value driver) are unaffected
+    because we explicitly defer when one is available, and the
+    sLimit > 0.5 chassis early-return still holds.
+  - Pass 2 / Pass 3 stencil walks are unaffected when sLimit is
+    healthy. They only get skipped when sLimit is weak, and at
+    weak strength their +1 overhead exceeds the delivered value.
+  - The threshold WEAK_LIMIT = 1.8 is conservative: enemy/1.4 +
+    0.45 <= 1.8 already requires enemy < 1.89, so the only kills
+    we'd skip at the boundary are tiny-enemy captures that the
+    chassis itself would rate low. We don't lose meaningful kills.
+
+Tech mirrors g14_8d5369's validated chassis loadout {move:76,
+stack:0, prod:16, atk:5, def:3}. Idle behavior is pure addition.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) {
+      Parent.act(army, game);
+      return;
+    }
+    if (sLimit < WEAK_LIMIT) {
+      const pid = army.player.id;
+      if (!hasBeatableAdjacentEnemy(tile, pid, sLimit)) return;
+    }
+    Parent.act(army, game);
+  },
+};

--- a/src/strategies/Forge.js
+++ b/src/strategies/Forge.js
@@ -1,0 +1,185 @@
+import { sumStrength } from "../core/Army.js";
+import Parent from "./Conqueror_g13_b41df9.js";
+import Conqueror from "./Conqueror.js";
+
+const BONUS = 1.4;
+const MARGIN = 0.45;
+const BACKING_WEIGHT = 0.4;
+const RETAKE_W = 0.8;
+const FRIENDLY_W = 0.4;
+const RETAKE_VETO = 1.5;
+// Threshold at which we decide a captured tile faces a fight next
+// tick and over-committing pays. Set just below the chassis's
+// RETAKE_VETO so we still over-commit on tiles with nontrivial
+// enemy backup that the chassis is willing to take anyway.
+const FIGHT_THRESHOLD = 0.5;
+
+const HEMI = (() => {
+  const w = [], e = [], n = [], s = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = 0; j < 5; j++) {
+      const idx = i * 5 + j;
+      const dx = j - 2;
+      const dy = i - 2;
+      if (dx < 0) w.push(idx);
+      if (dx > 0) e.push(idx);
+      if (dy < 0) n.push(idx);
+      if (dy > 0) s.push(idx);
+    }
+  }
+  return [w, e, n, s];
+})();
+
+export default {
+  name: "Forge",
+  author: "claude",
+  version: 1,
+  description:
+    "Conqueror_g13 chassis with conditional max-commit: when the chassis's Pass 1 picks a kill AND the captured tile will face a non-trivial enemy next tick (max-backup >= 0.5), commit attackPower instead of min-overkill. On safe captures (no real backup), commit min-overkill as the chassis does — keep the surplus on the source.",
+  summary: `Hammer's thesis is that under combatModel="lanchester" +
+cost = power*dist + 1, max-commit is strictly better per delivered
+strength: surplus comes back as raw post-fight strength via
+sqrt(W^2 - L^2), and the +1 overhead is paid once regardless of
+move size. Hammer applies that universally.
+
+Forge is a more conservative reading. The thesis applies cleanly
+when the captured tile actually needs the surplus — i.e., when
+there's an adjacent enemy that will fight us back next tick. On
+safe captures (kill target has no enemy in its other neighbors,
+or only trivially small ones), the surplus on the captured tile
+sits idle until it gets absorbed back into reinforcement flow,
+and meanwhile the SOURCE tile is starved for next tick. The
+chassis's min-overkill (enemy/1.4 + 0.45) is correct in that case.
+
+Rule:
+  - Pass 1 picks a kill via the same hemisphere/territory/retake
+    logic as the chassis. The picker's "backup" value (max enemy
+    strength among the target's other neighbors, capped at 1.5
+    via RETAKE_VETO so we never even reach this branch with truly
+    contested captures) tells us whether the captured tile faces
+    a fight next tick.
+  - If backup >= FIGHT_THRESHOLD (0.5), commit attackPower
+    (Hammer-style). The captured tile lands with extra raw
+    strength to either survive a counter-attack or convert into
+    a follow-up kill.
+  - If backup < 0.5, commit min-overkill (chassis-style). The
+    capture is safe; surplus is better held on the source for
+    next-tick options.
+
+Why this is plausibly a strict-upgrade chassis variant rather than
+just Hammer-lite:
+  - Hammer max-commits universally; on the ~50%+ of kills that
+    are safe, that strands strength on a quiet captured tile
+    while the source tile loses its action budget next tick.
+  - The chassis's RETAKE_VETO (1.5) guarantees that any kill we
+    PICK has backup < 1.5 — a narrow band. FIGHT_THRESHOLD = 0.5
+    splits that band into "trivial backup, hold reserves" and
+    "real backup, dump surplus". The split is roughly where
+    Lanchester's preservation actually pays.
+
+Pass 2 (Conqueror.act fallback when no kill but other target) and
+Pass 3 (stencil walk) are inherited from Parent unchanged. The
+thesis is local to commit sizing on chosen kills.
+
+Tech mirrors the chassis champion {move:76, stack:0, prod:16,
+atk:5, def:3} so the commit-sizing delta is isolated.`,
+  tech: { move: 76, stack: 0, prod: 16, atk: 5, def: 3 },
+  act(army, game) {
+    const tile = army.tile;
+    if (!tile) return;
+    const sLimit = army.attackPower;
+    if (sLimit <= 0.5) {
+      Conqueror.act(army, game);
+      return;
+    }
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+    const stencil = tile.stencil5;
+    const viewer = army.player;
+
+    let bestKill = null;
+    let bestScore = -Infinity;
+    let bestNeeded = 0;
+    let bestBackup = 0;
+    let hasOtherTarget = false;
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) { hasOtherTarget = true; continue; }
+      let friendlyArmy = null;
+      let enemy = 0;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) friendlyArmy = a;
+        else enemy += a.strength;
+      }
+      if (enemy > 0) {
+        const needed = enemy / BONUS + MARGIN;
+        if (needed > sLimit) continue;
+
+        let backup = 0;
+        let friend = 0;
+        const tn = t.neighbors;
+        for (let j = 0; j < 4; j++) {
+          const tt = tn[j];
+          if (!tt || tt === tile) continue;
+          const ttArmies = tt.armies;
+          let tnE = 0;
+          let tnF = 0;
+          for (let k = 0; k < ttArmies.length; k++) {
+            const a = ttArmies[k];
+            if (a.player.id === pid) tnF += a.strength;
+            else tnE += a.strength;
+          }
+          if (tnE > backup) backup = tnE;
+          if (tnF > friend) friend = tnF;
+        }
+
+        if (backup >= RETAKE_VETO) continue;
+
+        let backing = 0;
+        if (stencil) {
+          const idxs = HEMI[i];
+          for (let k = 0; k < idxs.length; k++) {
+            const cell = stencil[idxs[k]];
+            if (!cell) continue;
+            const cArmies = cell.armies;
+            if (cArmies.length === 0) continue;
+            const e = -sumStrength(cArmies, viewer);
+            if (e > 0) backing += e;
+          }
+        }
+
+        const score = enemy
+          + BACKING_WEIGHT * backing
+          - RETAKE_W * backup
+          + FRIENDLY_W * friend;
+        if (score > bestScore) {
+          bestScore = score;
+          bestNeeded = needed;
+          bestBackup = backup;
+          bestKill = t;
+        }
+        continue;
+      }
+      if (friendlyArmy && friendlyArmy.strength < friendlyArmy.maxStrength - 0.5) {
+        hasOtherTarget = true;
+      }
+    }
+    if (bestKill) {
+      // Conditional commit: max-commit only when the captured
+      // tile faces a real fight next tick. Otherwise min-overkill
+      // to keep surplus on the source.
+      const power = bestBackup >= FIGHT_THRESHOLD ? sLimit : bestNeeded;
+      army.attack(bestKill, power);
+      return;
+    }
+
+    if (hasOtherTarget) {
+      Conqueror.act(army, game);
+      return;
+    }
+    Parent.act(army, game);
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -44,6 +44,9 @@ import Sniper from "./Sniper.js";
 import Hammer from "./Hammer.js";
 import Stockpile from "./Stockpile.js";
 import Reservoir from "./Reservoir.js";
+import Beachhead from "./Beachhead.js";
+import Cordon from "./Cordon.js";
+import Forge from "./Forge.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -99,6 +102,9 @@ export const ALL_STRATEGY_LIST = [
   Hammer,
   Stockpile,
   Reservoir,
+  Beachhead,
+  Cordon,
+  Forge,
   ...GENERATED,
   ...DESCENDANTS,
 ];


### PR DESCRIPTION
## Summary
This PR introduces three new strategy variants that extend the Conqueror_g13 chassis with targeted optimizations for different tactical scenarios. Each variant preserves the core chassis logic while adding specialized decision-making for specific game situations.

## Key Changes

**Beachhead** - Kill-target scoring enhancement
- Adds empty-flank bonus to the Pass 1 kill picker's scoring function
- Prioritizes captures that create more expansion opportunities (empty neighbor tiles)
- Uses `EMPTY_FLANK_W = 0.35` weight to break ties in favor of better frontline geometry
- Preserves all existing anti-retake and hemisphere-backing logic

**Cordon** - Weak-action efficiency gate
- Prevents inefficient moves when army strength is below `WEAK_LIMIT = 1.8`
- Idles instead of spending the +1 move overhead on low-yield expansions
- Defers to chassis when either: (1) attackPower is healthy, or (2) a beatable adjacent enemy exists
- Allows weak tiles to accumulate strength naturally rather than pay overhead costs

**Forge** - Conditional commit sizing
- Implements dynamic attack power allocation based on captured tile vulnerability
- Commits full `attackPower` when target faces real enemy backup (>= 0.5 strength)
- Commits minimal overkill (`enemy/1.4 + 0.45`) on safe captures to preserve source reserves
- Balances Lanchester's strength-preservation thesis with practical source-tile starvation concerns

## Implementation Details

- All three variants inherit from `Conqueror_g13_b41df9` as the fallback parent
- Each maintains the same tech loadout `{move:76, stack:0, prod:16, atk:5, def:3}` to isolate behavioral changes
- Shared constants (BONUS, MARGIN, RETAKE_VETO, etc.) ensure consistency with the chassis baseline
- Pass 2 and Pass 3 logic (reinforcement and stencil walks) remain unchanged across all variants
- All variants are registered in the strategy index for tournament play

https://claude.ai/code/session_01K1mtFFEy5ZFBbz3dmzAcXa