### PR TITLE
Add three new strategy implementations: Tidewatcher, Smith, and Coastal

### DIFF
--- a/src/strategies/Coastal.js
+++ b/src/strategies/Coastal.js
@@ -1,0 +1,100 @@
+import { balanceAttack } from "./helpers.js";
+
+export default {
+  name: "Coastal",
+  author: "claude",
+  version: 1,
+  description:
+    "Frontier-only actor: armies surrounded by friendlies sit and grow; armies on the border push hard with full surplus.",
+  summary: `Two-tier deployment. Coastal classifies each army by whether
+it touches the edge of our territory — if every neighbor is a
+friendly-occupied tile of our own, the army is *interior* and does
+nothing. Interior strength accumulates passively until a neighbor
+flips (we lose a tile, or a friendly army moves out), at which point
+the now-frontier army flushes into the gap.
+
+Frontier behavior is intentionally aggressive: balanceAttack against
+the weakest neighbor (matching SlowAndSteady's controlled pressure),
+but with a permission to commit attackPower against any beatable
+enemy stack — interior armies will keep feeding strength forward, so
+frontier armies don't need to hoard.
+
+Why this works: the standard "skip when low strength" pattern (Cautious)
+under-utilizes any army that *happens* to be at low strength even
+when it's the only thing standing between an enemy and our base. The
+better signal is *position*, not strength. An interior army at 4
+strength is wasted; a frontier army at 4 strength is the front line.
+
+Tier rules per army:
+- Friendly count = number of neighbors occupied by our own armies.
+- Interior (friendly count == valid-neighbor count): hold.
+- Frontier: among non-friendly neighbors, attack the one with least
+  enemy presence (empty preferred at flat 1.2; enemy via balanceAttack;
+  beatable strong enemy via attackPower if margin > 1.5).
+
+Weak against: turtles that pack the same map quadrant with us — if
+every neighbor is friendly we never act, and a slow-rolling enemy
+elsewhere snowballs uncontested.
+Strong against: scattered/dispersed pools where every Coastal army
+sits exactly on the boundary by the mid-game and can punch outward
+in concert.`,
+  act(army) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+
+    let validCount = 0;
+    let friendlyCount = 0;
+    let bestEmpty = null;
+    let weakestEnemyTile = null;
+    let weakestEnemyStr = Infinity;
+    let strongBeatable = null;
+    let strongBeatableStr = 0;
+
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      validCount++;
+      const armies = t.armies;
+      if (armies.length === 0) {
+        if (!bestEmpty) bestEmpty = t;
+        continue;
+      }
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) {
+        friendlyCount++;
+        continue;
+      }
+      if (enemy < weakestEnemyStr) {
+        weakestEnemyStr = enemy;
+        weakestEnemyTile = t;
+      }
+      if (enemy + 1.5 < army.strength && enemy > strongBeatableStr) {
+        strongBeatableStr = enemy;
+        strongBeatable = t;
+      }
+    }
+
+    if (validCount === 0) return;
+    if (friendlyCount === validCount) return;
+
+    if (bestEmpty && army.strength > 2.5) {
+      army.attack(bestEmpty, 1.2);
+      return;
+    }
+    if (strongBeatable) {
+      army.attack(strongBeatable, army.attackPower);
+      return;
+    }
+    if (weakestEnemyTile) {
+      balanceAttack(army, weakestEnemyTile);
+    }
+  },
+};

--- a/src/strategies/Smith.js
+++ b/src/strategies/Smith.js
@@ -1,0 +1,87 @@
+export default {
+  name: "Smith",
+  author: "claude",
+  version: 1,
+  description:
+    "Picks the move with the best (territory + strength denied) / (strength spent) ratio across all adjacent options.",
+  summary: `Pure economist. Every adjacent move is a transaction with a
+cost (strength we send out and lose access to) and a return (territory
+gained, plus enemy strength denied to its owner). Smith scores every
+neighbor on this ratio and picks the best deal that survives a minimum
+margin.
+
+Scoring per neighbor:
+- Friendly tile: skip (no transaction; reinforcement is not Smith's
+  trade — let the friendly army fend for itself).
+- Empty tile: value = 1.0 (territory), cost = 1.2 (attack-validity
+  floor + epsilon), ratio ~= 0.83.
+- Enemy tile beatable with margin: value = 1.0 + 0.5 * enemy
+  (territory + half the strength denied — the other half they would
+  have lost passively to attrition anyway), cost = enemy + 1.0
+  (kill cost). Ratio improves as enemies get smaller relative to
+  the +1 overkill, peaking on tiny stacks.
+- Enemy tile not cleanly beatable: skip.
+
+Pick the highest ratio that clears 0.7. Below that threshold we hold
+strength — a bad trade is worse than no trade because PixelWars
+punishes failed attacks (you lose strength *and* don't gain territory).
+
+The min-overkill kill cost (enemy + 1.0) means home strength keeps
+regenerating Vampire-style. The empty-tile value of 1.2 (vs Scout's
+1.2) gives fast frontier expansion when no enemies are around. The
+ratio-driven choice means Smith correctly prefers a 1-strength enemy
+kill (ratio ~= 0.75) over a 5-strength enemy kill (ratio ~= 0.58)
+even though the latter denies more strength — because the cheaper
+deal lets us recycle strength faster across more ticks.
+
+Weak against: bots that mass single huge stacks, since Smith's "skip
+if not cleanly beatable" leaves no answer to a wall of strength.
+Strong against: spread-out attackers, where there's always a 1- or
+2-strength stragger Smith can pick off cheaply.`,
+  act(army) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+
+    let bestRatio = 0.7;
+    let bestTile = null;
+    let bestPower = 0;
+
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) {
+        if (army.strength > 2.3) {
+          const ratio = 1.0 / 1.2;
+          if (ratio > bestRatio) {
+            bestRatio = ratio;
+            bestTile = t;
+            bestPower = 1.2;
+          }
+        }
+        continue;
+      }
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) continue;
+      const cost = enemy + 1.0;
+      if (cost + 1.0 > army.strength) continue;
+      const value = 1.0 + 0.5 * enemy;
+      const ratio = value / cost;
+      if (ratio > bestRatio) {
+        bestRatio = ratio;
+        bestTile = t;
+        bestPower = cost;
+      }
+    }
+
+    if (bestTile) army.attack(bestTile, bestPower);
+  },
+};

--- a/src/strategies/Tidewatcher.js
+++ b/src/strategies/Tidewatcher.js
@@ -1,0 +1,89 @@
+export default {
+  name: "Tidewatcher",
+  author: "claude",
+  version: 1,
+  description:
+    "Watches each neighbor's enemy strength over time and strikes only when it dips well below its observed peak — a freshly-spent stack.",
+  summary: `Patience predator. Most "strike when weak" bots use absolute
+thresholds (Opportunist: enemy < 0.5*self; Vampire: enemy + 1 < self).
+Tidewatcher tracks the *temporal* signal instead — for each of the four
+neighbor directions it remembers the peak enemy strength it has ever
+observed there, and pounces when the current enemy stack has dropped to
+< 60% of that peak. The intuition: an enemy that was full and is now
+half-empty just spent strength attacking somewhere else, and the
+attacking pieces are not coming back this tick. That's when neighbor
+fights are cheapest.
+
+Per-army state on \`army._peak\` is a Float32Array of length 4 (W, E, N,
+S). On every tick we update the peak and look for at least one
+direction where (a) current enemy is beatable with margin and (b)
+current/peak < 0.6. We commit minimum-overkill (enemy + 1.0) so the
+home tile keeps regenerating.
+
+Fallbacks:
+- If no neighbor has ever seen enemy presence (early game on a quiet
+  flank), expand opportunistically into the weakest empty neighbor for
+  a flat 1.2 — we don't want to sit motionless and forfeit territory.
+- If all neighbors are friendlies or peakless and we're already at
+  full strength, do nothing.
+
+Loses to: bots that maintain *constant* pressure (Conqueror, Surge),
+because their peak == current and the trigger never fires.
+Wins against: Aggressive, Berserker, Vampire — bots whose strength
+oscillates because they keep spending it on attacks.`,
+  act(army) {
+    const tile = army.tile;
+    if (!tile) return;
+    const neighbors = tile.neighbors;
+    const pid = army.player.id;
+
+    if (!army._peak) army._peak = new Float32Array(4);
+    const peak = army._peak;
+
+    let bestIdx = -1;
+    let bestEnemy = 0;
+    let emptyTile = null;
+    let emptyWeak = Infinity;
+
+    for (let i = 0; i < 4; i++) {
+      const t = neighbors[i];
+      if (!t) continue;
+      const armies = t.armies;
+      if (armies.length === 0) {
+        if (emptyWeak > 0) {
+          emptyTile = t;
+          emptyWeak = 0;
+        }
+        continue;
+      }
+      let enemy = 0;
+      let friendly = false;
+      for (let k = 0; k < armies.length; k++) {
+        const a = armies[k];
+        if (a.player.id === pid) { friendly = true; break; }
+        enemy += a.strength;
+      }
+      if (friendly) continue;
+
+      if (enemy > peak[i]) peak[i] = enemy;
+
+      const beatable = enemy + 1.1 < army.strength;
+      const dipped = peak[i] > 0 && enemy < peak[i] * 0.6;
+      if (beatable && dipped && enemy > bestEnemy) {
+        bestEnemy = enemy;
+        bestIdx = i;
+      }
+    }
+
+    if (bestIdx >= 0) {
+      army.attack(neighbors[bestIdx], bestEnemy + 1.0);
+      return;
+    }
+
+    // No tide-strike available. Plant cheap flag on an empty if we have
+    // surplus strength; otherwise wait.
+    if (emptyTile && army.strength > 2.5) {
+      army.attack(emptyTile, 1.2);
+    }
+  },
+};

--- a/src/strategies/index.js
+++ b/src/strategies/index.js
@@ -44,6 +44,9 @@ import Sniper from "./Sniper.js";
 import Hammer from "./Hammer.js";
 import Stockpile from "./Stockpile.js";
 import Reservoir from "./Reservoir.js";
+import Tidewatcher from "./Tidewatcher.js";
+import Smith from "./Smith.js";
+import Coastal from "./Coastal.js";
 import { GENERATED } from "./generated.js";
 import { DESCENDANTS } from "./descendants.js";
 import { ARCHIVED } from "./archive.js";
@@ -99,6 +102,9 @@ export const ALL_STRATEGY_LIST = [
   Hammer,
   Stockpile,
   Reservoir,
+  Tidewatcher,
+  Smith,
+  Coastal,
   ...GENERATED,
   ...DESCENDANTS,
 ];


### PR DESCRIPTION
## Summary
This PR introduces three new AI strategies for the PixelWars game, each with distinct tactical approaches to territory control and combat.

## Key Changes
- **Tidewatcher**: A temporal-tracking strategy that monitors peak enemy strength in each direction and attacks only when enemy stacks dip below 60% of their observed peak, exploiting windows when enemies have recently spent strength elsewhere
- **Smith**: An economic optimizer that scores every adjacent move by the (territory + strength denied) / (strength spent) ratio, selecting moves above a 0.7 threshold to ensure profitable trades
- **Coastal**: A position-based two-tier system that classifies armies as either interior (surrounded by friendlies, accumulating strength) or frontier (on territory borders, aggressively attacking), prioritizing position over raw strength as the decision signal

## Notable Implementation Details
- **Tidewatcher** uses per-army state (`army._peak`) as a Float32Array to track historical peak enemy strength across four directions
- **Smith** implements a pure economic model with distinct scoring for empty tiles (ratio ~0.83) vs. enemy tiles (ratio improves with smaller stacks), with a 0.7 minimum threshold to avoid bad trades
- **Coastal** uses neighbor classification (friendly count vs. valid neighbor count) to determine army tier, with frontier armies permitted to commit full `attackPower` against beatable enemies since interior armies feed strength forward
- All three strategies are registered in the strategy index and exported in `ALL_STRATEGY_LIST`

https://claude.ai/code/session_01FMBAsBbEt6ycd8iCT75Z85