### PR TITLE
Add conflict residue visualization to game renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
               <option value="line">Line</option>
             </select>
           </label>
+          <label><input id="toggle-conflicts" type="checkbox" checked />Conflict residue</label>
           <label><input id="toggle-overlay" type="checkbox" />Strategy overlay</label>
           <label><input id="toggle-3d" type="checkbox" />3D view (height = army size)</label>
         </div>

--- a/src/client/GameView.js
+++ b/src/client/GameView.js
@@ -102,6 +102,9 @@ export class GameView {
     this.armies = [];
     this.recentMoves = [];
     this.moveFadeTicks = 8;
+    this.recentConflicts = [];
+    this.conflictFadeTicks = 45;
+    this.maxArmy = 6;
     this.history = [];
     // Toggled by the renderer's territory check; safe to leave false
     // since the worker recomputes territory before each snapshot.
@@ -154,6 +157,7 @@ export class GameView {
     this.armies = [];
     this._armiesById.clear();
     this.recentMoves = [];
+    this.recentConflicts = [];
     this.history = [];
     if (this.map.width === width && this.map.height === height && this.map.wrap === wrap) {
       for (const t of this.map.tiles) t.armies.length = 0;
@@ -186,6 +190,8 @@ export class GameView {
     this.tick = snapshot.tick;
     this.elapsed = snapshot.elapsed;
     this.moveFadeTicks = snapshot.moveFadeTicks;
+    if (snapshot.conflictFadeTicks != null) this.conflictFadeTicks = snapshot.conflictFadeTicks;
+    if (snapshot.maxArmy != null) this.maxArmy = snapshot.maxArmy;
 
     // Reuse map if dims unchanged. The init flow calls applyMap
     // explicitly; here we only catch a config mismatch defensively.
@@ -245,6 +251,7 @@ export class GameView {
 
     // Recent moves: plain copies, no shared refs.
     this.recentMoves = snapshot.recentMoves || [];
+    this.recentConflicts = snapshot.recentConflicts || [];
 
     // History: replace wholesale - bounded by maxHistory in the engine.
     this.history = snapshot.history || [];

--- a/src/core/Game.js
+++ b/src/core/Game.js
@@ -60,6 +60,22 @@ export class Game {
     this._territoryDirty = true;
     this.recentMoves = [];
     this.moveFadeTicks = 8;
+    // Recently-resolved combats, used by the renderer to paint a red
+    // residue on contested tiles. magnitude = total strength engaged
+    // in the fight; the renderer fades alpha with age and scales by
+    // magnitude so heavy/sustained conflicts read as deeper red.
+    this.recentConflicts = [];
+    this.conflictFadeTicks = 45;
+  }
+
+  recordConflict(tile, magnitude) {
+    if (!tile || !(magnitude > 0)) return;
+    this.recentConflicts.push({
+      x: tile.pos.x,
+      y: tile.pos.y,
+      magnitude,
+      tick: this.tick,
+    });
   }
 
   recordMove(fromTile, toTile, player, power) {
@@ -241,6 +257,16 @@ export class Game {
       moves.length = w;
     }
 
+    if (this.recentConflicts.length > 0) {
+      const conflicts = this.recentConflicts;
+      const cutoff = tick - this.conflictFadeTicks;
+      let w = 0;
+      for (let i = 0; i < conflicts.length; i++) {
+        if (conflicts[i].tick > cutoff) conflicts[w++] = conflicts[i];
+      }
+      conflicts.length = w;
+    }
+
     if (this._deadCount > 32 && this._deadCount * 4 > armies.length) {
       this._compactArmies();
     }
@@ -321,6 +347,7 @@ export class Game {
     this._deadCount = 0;
     this._dirtyTiles.length = 0;
     this.recentMoves.length = 0;
+    this.recentConflicts.length = 0;
     this.tick = 0;
     this.elapsed = 0;
     this.history.length = 0;

--- a/src/core/Tile.js
+++ b/src/core/Tile.js
@@ -92,6 +92,15 @@ export class Tile {
     const game = grouped[0] && grouped[0].game;
     const bonus = (game && game.attackerBonus) || 1;
     const model = (game && game.combatModel) || "linear";
+
+    // Total strength engaged across all sides — fed to the renderer as
+    // conflict magnitude so the red residue scales with fight size.
+    // Only meaningful when at least two distinct players collided here;
+    // single-player merges are not conflicts.
+    let engagedStrength = 0;
+    if (grouped.length > 1) {
+      for (let i = 0; i < grouped.length; i++) engagedStrength += grouped[i].strength;
+    }
     const armyMult = (army) => {
       const m = army.player.techMults;
       if (army.isAttacker) return bonus * (m ? m.atk : 1);
@@ -136,6 +145,10 @@ export class Tile {
       survivor.isAttacker = false;
       this.armies.push(survivor);
       survivor.tile = this;
+    }
+
+    if (engagedStrength > 0 && game && game.recordConflict) {
+      game.recordConflict(this, engagedStrength);
     }
   }
 

--- a/src/engine/host.js
+++ b/src/engine/host.js
@@ -320,6 +320,7 @@ export class EngineHost {
     });
 
     const recentMoves = game.recentMoves.map((m) => ({ ...m }));
+    const recentConflicts = game.recentConflicts.map((c) => ({ ...c }));
 
     // Strategy-overlay plan caches. Only included when the client has
     // toggled overlay on; otherwise we'd ship ~4 bytes/tile/player every
@@ -355,9 +356,12 @@ export class EngineHost {
       mapHeight: game.map.height,
       mapWrap: game.map.wrap,
       moveFadeTicks: game.moveFadeTicks,
+      conflictFadeTicks: game.conflictFadeTicks,
+      maxArmy: game.maxArmy,
       armies,
       playerTotals,
       recentMoves,
+      recentConflicts,
       history,
       plans,
     };

--- a/src/render/Renderer.js
+++ b/src/render/Renderer.js
@@ -11,6 +11,7 @@ export class Renderer {
     this.showTerritory = true;
     this.showGlow = true;
     this.showMoves = true;
+    this.showConflicts = true;
     this.showOverlay = false;
     // "circle" | "line": visual used to depict an in-flight move.
     this.moveStyle = "circle";
@@ -227,6 +228,8 @@ export class Renderer {
       ctx.stroke();
     }
 
+    if (this.showConflicts) this.drawConflicts();
+
     if (this.showMoves) this.drawMoves();
 
     this.drawArmies(now);
@@ -246,6 +249,36 @@ export class Renderer {
       const alpha = 0.10 + 0.20 * (owner.strength / owner.maxStrength);
       ctx.fillStyle = hexToRgba(owner.player.color, alpha);
       ctx.fillRect(tile.pos.x * ts, tile.pos.y * ts, ts, ts);
+    }
+  }
+
+  // Faint red residue on tiles where combat just resolved. Each
+  // recorded conflict paints a square whose alpha fades linearly to
+  // zero over conflictFadeTicks and scales with the strength engaged
+  // in that fight; overlapping conflicts compound via alpha blending,
+  // so a tile under sustained attack stays visibly red.
+  drawConflicts() {
+    const ctx = this.ctx;
+    const ts = this.tileSize;
+    const game = this.game;
+    const conflicts = game.recentConflicts;
+    if (!conflicts || conflicts.length === 0) return;
+    const fade = game.conflictFadeTicks || 30;
+    const tick = game.tick;
+    // A two-army max-strength clash is the natural saturation point;
+    // above that the alpha cap takes over.
+    const refMagnitude = Math.max(1, (game.maxArmy || 6) * 2);
+    const maxAlpha = 0.55;
+    for (let i = 0; i < conflicts.length; i++) {
+      const c = conflicts[i];
+      const age = tick - c.tick;
+      if (age >= fade || age < 0) continue;
+      const ageFactor = 1 - age / fade;
+      const sizeFactor = Math.min(1, c.magnitude / refMagnitude);
+      const alpha = maxAlpha * ageFactor * sizeFactor;
+      if (alpha <= 0) continue;
+      ctx.fillStyle = `rgba(220,40,40,${alpha})`;
+      ctx.fillRect(c.x * ts, c.y * ts, ts, ts);
     }
   }
 

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -17,6 +17,7 @@ export class Controls {
     this.toggleTerritory = $("#toggle-territory");
     this.toggleGlow = $("#toggle-glow");
     this.toggleMoves = $("#toggle-moves");
+    this.toggleConflicts = $("#toggle-conflicts");
     this.moveStyle = $("#move-style");
     this.toggleOverlay = $("#toggle-overlay");
     this.toggle3D = $("#toggle-3d");
@@ -51,6 +52,12 @@ export class Controls {
       this.app.renderer.showMoves = this.toggleMoves.checked;
       this.app.markDirty();
     });
+    if (this.toggleConflicts) {
+      this.toggleConflicts.addEventListener("change", () => {
+        this.app.renderer.showConflicts = this.toggleConflicts.checked;
+        this.app.markDirty();
+      });
+    }
     if (this.moveStyle) {
       this.moveStyle.value = this.app.renderer.moveStyle;
       this.moveStyle.addEventListener("change", () => {


### PR DESCRIPTION
## Summary
This PR adds a visual indicator for recently-resolved combat on the game board. When armies clash on a tile, a faint red overlay appears and fades over time, with intensity scaling based on the magnitude of the conflict. This provides players with better feedback about where battles are occurring.

## Key Changes

- **Game conflict tracking**: Added `recentConflicts` array and `recordConflict()` method to `Game` class to record combat events with position, magnitude, and timestamp
- **Conflict recording in combat resolution**: Modified `Tile.resolveConflict()` to calculate total engaged strength across all combatants and call `recordConflict()` when multiple players clash
- **Renderer visualization**: Implemented `drawConflicts()` method in `Renderer` that paints semi-transparent red squares on conflict tiles, with alpha fading linearly over `conflictFadeTicks` and scaling with engagement magnitude
- **Conflict cleanup**: Added logic to prune expired conflicts from the `recentConflicts` array during game tick updates
- **Client-side state management**: Updated `GameView` to track and sync conflict data from server snapshots
- **UI toggle**: Added "Conflict residue" checkbox to controls that toggles the `showConflicts` renderer flag
- **Network serialization**: Modified `EngineHost` to include `recentConflicts`, `conflictFadeTicks`, and `maxArmy` in game snapshots sent to clients

## Implementation Details

- Conflicts only register when 2+ distinct players engage (single-player merges are excluded)
- Red residue uses `rgba(220,40,40,alpha)` with max alpha of 0.55 to remain subtle
- Magnitude scaling uses a reference point of `maxArmy * 2` (typical max-strength clash) to normalize intensity
- Conflicts fade over 45 ticks by default, with age-based alpha interpolation
- Overlapping conflicts compound via alpha blending, so sustained attacks appear darker red

https://claude.ai/code/session_012Qvgy8Q9x3NH8o3HGZiA4j