### PR TITLE
Rate-limit army movement to production rate

### DIFF
--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -76,10 +76,17 @@ otherwise the neutral `{20,20,20,20,20}` split applies. See
 
 ## The `act(army, game)` contract
 
-`act` is called once per army per tick. You decide what *this* army does;
-you don't see or control your other armies directly. State you store on
-`army` persists for the army's lifetime; state on `game` persists for the
-match.
+`act` is called once per accumulated *move credit*, not once per tick.
+Each army gains credit at the production rate (`growth × prodMult ×
+interval`) and `act` only runs when at least 1 credit has banked, then
+1 credit is deducted. This keeps movement frequency proportional to
+growth — doubling growth doubles both production and move rate, so the
+production:logistics ratio is invariant across game speeds. Credit is
+capped at 1 (no large stockpiles).
+
+You decide what *this* army does; you don't see or control your other
+armies directly. State you store on `army` persists for the army's
+lifetime; state on `game` persists for the match.
 
 ### What you read from `army`
 

--- a/src/core/Army.js
+++ b/src/core/Army.js
@@ -18,6 +18,14 @@ export class Army {
     this.isAttacker = false;
     this.lastTick = 0;
     this.bornAt = 0;
+    // Movement is rate-limited: act() runs once per accumulated credit,
+    // not once per tick. Credit ticks up at the production rate
+    // (growth × prodMult × interval), so movement frequency stays in
+    // proportion to growth no matter how the game-level rate is set —
+    // changing growth scales production AND movement together instead
+    // of just shifting the production:logistics ratio. Initialized
+    // off the seeded rng so armies don't all fire on the same tick.
+    this.moveCredit = game && game.rng ? game.rng() : 0;
   }
 
   // Maximum strength this army can commit to a single attack while
@@ -177,6 +185,16 @@ export class Army {
     this.strength = s;
     const strat = this.player.strategy;
     if (!strat) return;
+    // Accumulate move credit at the production rate. Cap at 1 so a
+    // bot that idled in its backfield can't unleash a stockpile of
+    // attacks when an opening appears — at most one ready move.
+    let credit = this.moveCredit + interval * growth * prodMult;
+    if (credit > 1) credit = 1;
+    if (credit < 1) {
+      this.moveCredit = credit;
+      return;
+    }
+    this.moveCredit = credit - 1;
     if (typeof strat === "function") strat(this, this.game);
     else if (typeof strat.act === "function") strat.act(this, this.game);
   }

--- a/src/ui/CodeModal.js
+++ b/src/ui/CodeModal.js
@@ -10,7 +10,9 @@ const SAMPLE_BOT = `// Paste a strategy module here. Self-contained ES modules o
 //
 // API quick reference (full notes: docs/strategies.md):
 //
-//   act(army, game)              runs every tick, once per army
+//   act(army, game)              runs once per accumulated move credit
+//                                (credit ticks at the production rate,
+//                                so movement scales with growth)
 //
 //   army.tile                    your tile (or null mid-move)
 //   army.tile.neighbors[i]       adjacent tile or null (W=0,E=1,N=2,S=3)


### PR DESCRIPTION
## Summary
Implement movement rate-limiting for armies so that `act()` is called based on accumulated move credit rather than every tick. This ensures movement frequency scales proportionally with growth, keeping the production-to-logistics ratio invariant across different game speeds.

## Changes
- **Army.js**: 
  - Added `moveCredit` property initialized from seeded RNG to desynchronize army actions
  - Implemented credit accumulation in `act()` method at the production rate (`growth × prodMult × interval`)
  - Added credit cap at 1 to prevent stockpiling of moves during idle periods
  - Movement only executes when credit ≥ 1, then 1 credit is deducted

- **docs/strategies.md**: 
  - Updated `act(army, game)` contract documentation to explain the new credit-based calling mechanism
  - Clarified that movement frequency now scales with growth, making the production:logistics ratio invariant

- **CodeModal.js**: 
  - Updated API quick reference to reflect that `act()` runs on move credit accumulation rather than every tick
  - Added brief explanation that movement scales with growth

## Implementation Details
The move credit system accumulates at the same rate as production (`growth × prodMult × interval`), ensuring that when growth changes, both production and movement frequency scale together. This prevents the game speed from affecting the strategic balance between production and logistics. Credit is capped at 1 to prevent armies from stockpiling moves while idle and then unleashing them when an opportunity appears.

https://claude.ai/code/session_01MvzprsAFxzmiryLDdkL3dq