### PR TITLE
Color bots by rating in lineup and replay views

### DIFF
--- a/src/client/EngineClient.js
+++ b/src/client/EngineClient.js
@@ -38,6 +38,24 @@ const PALETTE = [
   { color: "#7cffb2", accent: "#bbffd6" },
 ];
 
+// Build a per-slot palette permuted so the highest-rated bot in the
+// lineup gets PALETTE[0] (red), the next gets PALETTE[1], and so on.
+// Slots without a known rating fall to the back, ties keep their
+// original lineup order.
+function paletteByRank(lineupStrategies, ratings) {
+  const n = lineupStrategies.length;
+  const order = lineupStrategies.map((s, i) => {
+    const r = ratings?.[s?.name];
+    return { i, r: typeof r === "number" ? r : -Infinity };
+  });
+  order.sort((a, b) => (b.r - a.r) || (a.i - b.i));
+  const palette = new Array(n);
+  for (let rank = 0; rank < n; rank++) {
+    palette[order[rank].i] = PALETTE[rank % PALETTE.length];
+  }
+  return palette;
+}
+
 export class EngineClient {
   constructor() {
     this.game = new GameView();
@@ -71,8 +89,8 @@ export class EngineClient {
   // before the first snapshot arrives.
   // ------------------------------------------------------------------
 
-  loadCustom({ mapConfig, lineupStrategies, startPositions, seed, customStrategies = [] }) {
-    const palette = PALETTE.slice(0, lineupStrategies.length);
+  loadCustom({ mapConfig, lineupStrategies, startPositions, seed, customStrategies = [], ratings = null }) {
+    const palette = paletteByRank(lineupStrategies, ratings);
     const lineup = lineupStrategies.map((s) => s.name);
     this._primeView({
       mapConfig,
@@ -90,8 +108,8 @@ export class EngineClient {
     });
   }
 
-  loadReplay({ mapConfig, seed, lineupStrategies, lineupTech, startPositions }) {
-    const palette = PALETTE.slice(0, lineupStrategies.length);
+  loadReplay({ mapConfig, seed, lineupStrategies, lineupTech, startPositions, ratings = null }) {
+    const palette = paletteByRank(lineupStrategies, ratings);
     const lineup = lineupStrategies.map((s) => s.name);
     this._primeView({
       mapConfig,

--- a/src/main.js
+++ b/src/main.js
@@ -169,6 +169,7 @@ class App {
       lineupStrategies: strategies,
       lineupTech: entry.lineupTech ?? null,
       startPositions: entry.startPositions,
+      ratings: this.ratings,
     });
     this.renderer.resetView();
     this.renderer.resize();
@@ -259,6 +260,7 @@ class App {
       startPositions: positions,
       seed: useSeed,
       customStrategies: this.customBots.serializeUsed(strategies.map((s) => s.name)),
+      ratings: this.ratings,
     });
     this.renderer.resetView();
     this.renderer.resize();

--- a/src/ui/HUD.js
+++ b/src/ui/HUD.js
@@ -105,7 +105,16 @@ export class HUD {
       this.root.innerHTML = `<div class="hud-empty">No players. Add one in Sandbox.</div>`;
       return;
     }
-    for (const player of this.game.players.list) {
+    const ratings = this.app?.ratings;
+    const sorted = this.game.players.list.slice().sort((a, b) => {
+      const ra = ratings?.[a.strategy?.name];
+      const rb = ratings?.[b.strategy?.name];
+      const va = typeof ra === "number" ? ra : -Infinity;
+      const vb = typeof rb === "number" ? rb : -Infinity;
+      if (vb !== va) return vb - va;
+      return a.id - b.id;
+    });
+    for (const player of sorted) {
       const row = document.createElement("div");
       row.className = "player-row";
       row.style.setProperty("--player-color", player.color);


### PR DESCRIPTION
## Summary
This change introduces bot rating-based color assignment in the engine client. Bots are now colored according to their ratings, with the highest-rated bot receiving the first palette color (red), the next highest receiving the second color, and so on. This provides visual feedback about bot strength in both custom game and replay views.

## Key Changes
- **New `paletteByRank()` function**: Generates a per-slot color palette sorted by bot ratings. Bots without ratings fall to the back, and ties maintain their original lineup order.
- **Updated `loadCustom()` method**: Now accepts an optional `ratings` parameter and uses `paletteByRank()` instead of simple palette slicing.
- **Updated `loadReplay()` method**: Now accepts an optional `ratings` parameter and uses `paletteByRank()` instead of simple palette slicing.
- **Enhanced HUD player list**: Players are now sorted by rating (highest first) in the HUD display, with unrated players falling to the end while maintaining their original order.
- **Pass ratings through app**: Both custom game and replay loading now pass `this.ratings` to the engine client methods.

## Implementation Details
- The `paletteByRank()` function uses a stable sort that respects original lineup order for ties, ensuring consistent behavior.
- Unrated bots are assigned `-Infinity` as their rating value, guaranteeing they sort to the end.
- The HUD sorting mirrors the palette ranking logic for consistency across the UI.
- The `ratings` parameter is optional (defaults to `null`) to maintain backward compatibility.

https://claude.ai/code/session_01SUx3veU21ySK9SB8nQ9kPq